### PR TITLE
Feat: Add upon arrival instructions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "rescue",
+  "name": "sharingexcess",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/src/components/EditLocation/EditLocation.js
+++ b/src/components/EditLocation/EditLocation.js
@@ -108,13 +108,6 @@ export default function EditLocation() {
       />
       <Input
         type="text"
-        label="Upon Arrival Instructions *"
-        element_id="upon_arrival_instructions"
-        value={formData.upon_arrival_instructions}
-        onChange={handleChange}
-      />
-      <Input
-        type="text"
         label="Address Line 1 *"
         element_id="address1"
         value={formData.address1}
@@ -146,6 +139,13 @@ export default function EditLocation() {
         label="Zip Code *"
         element_id="zip_code"
         value={formData.zip_code}
+        onChange={handleChange}
+      />
+      <Input
+        type="text"
+        label="Upon Arrival Instructions *"
+        element_id="upon_arrival_instructions"
+        value={formData.upon_arrival_instructions}
         onChange={handleChange}
       />
       <div className="is_primary">

--- a/src/components/EditLocation/EditLocation.js
+++ b/src/components/EditLocation/EditLocation.js
@@ -28,6 +28,7 @@ export default function EditLocation() {
   )
   const [formData, setFormData] = useState({
     name: '',
+    upon_arrival_instructions: '',
     address1: '',
     address2: '',
     city: '',
@@ -103,6 +104,13 @@ export default function EditLocation() {
         label="Location Nickname *"
         element_id="name"
         value={formData.name}
+        onChange={handleChange}
+      />
+      <Input
+        type="text"
+        label="Upon Arrival Instructions *"
+        element_id="upon_arrival_instructions"
+        value={formData.upon_arrival_instructions}
         onChange={handleChange}
       />
       <Input

--- a/src/components/EditLocation/utils.js
+++ b/src/components/EditLocation/utils.js
@@ -1,6 +1,7 @@
 export function initializeFormData(location, callback) {
   callback({
     name: location.name,
+    upon_arrival_instructions: location.upon_arrival_instructions,
     address1: location.address1,
     address2: location.address2,
     city: location.city,

--- a/src/components/Rescue/Rescue.js
+++ b/src/components/Rescue/Rescue.js
@@ -169,7 +169,7 @@ export default function Rescue() {
           <ExternalLink url={pickup_directions_url}>
             Get Directions{' >'}
           </ExternalLink>
-          <p style={{marginTop: "1em"}}>
+          <p style={{ marginTop: '1em' }}>
             Pickup Instruction: {pickup_location.upon_arrival_instructions}
           </p>
         </div>
@@ -187,7 +187,7 @@ export default function Rescue() {
           <ExternalLink url={delivery_directions_url}>
             Get Directions{' >'}
           </ExternalLink>
-          <p style={{marginTop: "1em"}}>
+          <p style={{ marginTop: '1em' }}>
             Dropoff Instruction: {delivery_location.upon_arrival_instructions}
           </p>
         </div>

--- a/src/components/Rescue/Rescue.js
+++ b/src/components/Rescue/Rescue.js
@@ -169,6 +169,9 @@ export default function Rescue() {
           <ExternalLink url={pickup_directions_url}>
             Get Directions{' >'}
           </ExternalLink>
+          <p style={{marginTop: "1em"}}>
+            Pickup Instruction: {pickup_location.upon_arrival_instructions}
+          </p>
         </div>
         <Spacer />
         <div className="Location">
@@ -184,6 +187,9 @@ export default function Rescue() {
           <ExternalLink url={delivery_directions_url}>
             Get Directions{' >'}
           </ExternalLink>
+          <p style={{marginTop: "1em"}}>
+            Dropoff Instruction: {delivery_location.upon_arrival_instructions}
+          </p>
         </div>
       </>
     )


### PR DESCRIPTION
- added upon arrival instructions as a field upon location creation
- added arrival instructions for pickups and drop offs in during at rescue screen

![image](https://user-images.githubusercontent.com/19523341/103802446-c3d4c000-5014-11eb-9745-6cfa9e2c83aa.png)
Upon arrival instructions when both locations' instructions exist

![image](https://user-images.githubusercontent.com/19523341/103802525-df3fcb00-5014-11eb-8e4d-2497cc183267.png)
View when instructions do not exist

**Notes**
- Not the best UI, but it will change soon anyway since we'll need to re-work the rescue delivery UX
- Forgot that styles in React need to be CamelCase and not kebab-case 😢