### PR TITLE
Location Contact Info

### DIFF
--- a/src/components/EditLocation/EditLocation.js
+++ b/src/components/EditLocation/EditLocation.js
@@ -27,12 +27,14 @@ export default function EditLocation() {
   )
   const [formData, setFormData] = useState({
     name: '',
-    upon_arrival_instructions: '',
+    contact_name: '',
+    contact_phone: '',
     address1: '',
     address2: '',
     city: '',
     state: '',
     zip_code: '',
+    upon_arrival_instructions: '',
     is_primary: false,
   })
   const [error, setError] = useState()
@@ -117,6 +119,20 @@ export default function EditLocation() {
         label="Location Nickname *"
         element_id="name"
         value={formData.name}
+        onChange={handleChange}
+      />
+      <Input
+        type="text"
+        label="Contact Name"
+        element_id="contact_name"
+        value={formData.contact_name}
+        onChange={handleChange}
+      />
+      <Input
+        type="tel"
+        label="Contact Phone"
+        element_id="contact_phone"
+        value={formData.contact_phone}
         onChange={handleChange}
       />
       <Input

--- a/src/components/EditLocation/EditLocation.js
+++ b/src/components/EditLocation/EditLocation.js
@@ -123,14 +123,14 @@ export default function EditLocation() {
       />
       <Input
         type="text"
-        label="Contact Name"
+        label="Contact Name *"
         element_id="contact_name"
         value={formData.contact_name}
         onChange={handleChange}
       />
       <Input
         type="tel"
-        label="Contact Phone"
+        label="Contact Phone *"
         element_id="contact_phone"
         value={formData.contact_phone}
         onChange={handleChange}

--- a/src/components/EditLocation/utils.js
+++ b/src/components/EditLocation/utils.js
@@ -1,12 +1,14 @@
 export function initializeFormData(location, callback) {
   callback({
     name: location.name,
-    upon_arrival_instructions: location.upon_arrival_instructions,
+    contact_name: location.contact_name,
+    contact_phone: location.contact_phone,
     address1: location.address1,
     address2: location.address2,
     city: location.city,
     state: location.state,
     zip_code: location.zip_code,
+    upon_arrival_instructions: location.upon_arrival_instructions,
     is_primary: location.is_primary,
   })
 }

--- a/src/components/EditLocation/utils.js
+++ b/src/components/EditLocation/utils.js
@@ -1,16 +1,26 @@
 export function initializeFormData(location, callback) {
   callback({
     name: location.name,
-    contact_name: location.contact_name,
-    contact_phone: location.contact_phone,
+    contact_name: location.contact_name ? location.contact_name : '',
+    contact_phone: location.contact_phone ? location.contact_phone : '',
     address1: location.address1,
     address2: location.address2,
     city: location.city,
     state: location.state,
     zip_code: location.zip_code,
-    upon_arrival_instructions: location.upon_arrival_instructions,
+    upon_arrival_instructions: location.upon_arrival_instructions
+      ? location.upon_arrival_instructions
+      : '',
     is_primary: location.is_primary,
   })
 }
 
-export const required_fields = ['name', 'address1', 'city', 'state', 'zip_code']
+export const required_fields = [
+  'name',
+  'contact_name',
+  'contact_phone',
+  'address1',
+  'city',
+  'state',
+  'zip_code',
+]

--- a/src/components/Route/Route.js
+++ b/src/components/Route/Route.js
@@ -132,6 +132,18 @@ function Route() {
                         {s.location.upon_arrival_instructions}
                       </h6>
                     ) : null}
+                    {s.location.contact_name ? (
+                      <h6>
+                        <span>Contact Name: </span>
+                        {s.location.contact_name}
+                      </h6>
+                    ) : null}
+                    {s.location.contact_phone ? (
+                      <h6>
+                        <span>Contact Phone: </span>
+                        {s.location.contact_phone}
+                      </h6>
+                    ) : null}
                   </div>
                   {i === 0 ||
                   (stops[i - 1].report &&

--- a/src/components/Route/Route.js
+++ b/src/components/Route/Route.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { useDocumentData } from 'react-firebase-hooks/firestore'
-import { getCollection } from '../../helpers/helpers'
+import { getCollection, formatPhoneNumber } from '../../helpers/helpers'
 import Loading from '../Loading/Loading'
 import moment from 'moment'
 import UserIcon from '../../assets/user.svg'
@@ -138,10 +138,12 @@ function Route() {
                         {s.location.contact_name}
                       </h6>
                     ) : null}
-                    {s.location.contact_phone ? (
+                    {formatPhoneNumber(s.location.contact_phone) ? (
                       <h6>
-                        <span>Contact Phone: </span>
-                        {s.location.contact_phone}
+                        <span>Contact Phone:</span>
+                        <ExternalLink url={'tel:' + s.location.contact_phone}>
+                          <p>{formatPhoneNumber(s.location.contact_phone)}</p>
+                        </ExternalLink>
                       </h6>
                     ) : null}
                   </div>


### PR DESCRIPTION
Adding contact info to individual locations and displaying them when user views information for a rescue.

**Notes**
- some of the new fields added don't exist for some of the locations added in the past. this results in some odd bugs as occasionally when editing forms, the field will be set to `null` as opposed to an empty string (or something sensible)


![image](https://user-images.githubusercontent.com/19523341/103932982-48dcd980-50e8-11eb-8eea-a73036c57d82.png)
