### PR TITLE
Bug: Add org to firebase submit on new location

### DIFF
--- a/src/components/EditLocation/EditLocation.js
+++ b/src/components/EditLocation/EditLocation.js
@@ -66,6 +66,7 @@ export default function EditLocation() {
           .set(
             {
               id: new_loc_id,
+              org_id: id,
               ...formData,
             },
             { merge: true }


### PR DESCRIPTION
Small fix. Since the `org_id` was omitted, new locations created were not shown with the organization. 