### PR TITLE
fix: check if existing user is defined before attempting to access fields

### DIFF
--- a/src/components/Auth/utils.js
+++ b/src/components/Auth/utils.js
@@ -18,11 +18,15 @@ export async function updatePublicUserProfile(user) {
   const update_payload = {
     id: user.uid,
     email: user.email,
-    name: existing_user.displayName || user.displayName,
-    icon: existing_user.icon || user.photoURL,
+    name:
+      existing_user !== undefined
+        ? existing_user.displayName
+        : user.displayName,
+    icon: existing_user !== undefined ? existing_user.icon : user.photoURL,
     created_at:
-      existing_user.created_at ||
-      firebase.firestore.FieldValue.serverTimestamp(),
+      existing_user !== undefined
+        ? existing_user.created_at
+        : firebase.firestore.FieldValue.serverTimestamp(),
     last_login: firebase.firestore.FieldValue.serverTimestamp(),
   }
   setFirestoreData(['Users', user.uid], update_payload)


### PR DESCRIPTION
A small bug prevented new registrations from being added to the `Users` collection on Firestore. As a result, these new accounts were not viewable in the `Manage Users` page and admins would be unable to grant these new accounts basic access.

This should be a quick fix to that issue.