### PR TITLE
Allow user to delete form name entirely on Edit Org page 

### DIFF
--- a/src/components/EditOrganization/EditOrganization.js
+++ b/src/components/EditOrganization/EditOrganization.js
@@ -28,12 +28,14 @@ export default function EditOrganization() {
   const [file, setFile] = useState()
   const [errors, setErrors] = useState([])
   const [showErrors, setShowErrors] = useState(false)
+  const [reloadForm, setReloadForm] = useState(true)
 
   useEffect(() => {
-    if (org.name && !formData.name) {
+    if (org.name && !formData.name && reloadForm) {
       initializeFormData(org, setFormData)
+      setReloadForm(false)
     }
-  }, [org, formData])
+  }, [org, formData, reloadForm])
 
   useEffect(() => {
     handleOrgIcon(org.icon, setOrgIconFullUrl)
@@ -46,7 +48,10 @@ export default function EditOrganization() {
   }
 
   function validateFormData() {
-    if (formData.name === ' ') {
+    if (
+      !formData.name ||
+      !validator.isAlphanumeric(formData.name.split(' ')[0])
+    ) {
       errors.push('Missing in form data: Organization Name')
     }
     if (
@@ -174,6 +179,7 @@ export default function EditOrganization() {
         onClick={() => {
           handleSubmit()
           setShowErrors(true)
+          showErrors ? setReloadForm(true) : setReloadForm(false)
         }}
       >
         {id ? 'update organization' : 'create organization'}

--- a/src/components/EditOrganization/EditOrganization.js
+++ b/src/components/EditOrganization/EditOrganization.js
@@ -179,7 +179,7 @@ export default function EditOrganization() {
         onClick={() => {
           handleSubmit()
           setShowErrors(true)
-          showErrors ? setReloadForm(true) : setReloadForm(false)
+          setReloadForm(false)
         }}
       >
         {id ? 'update organization' : 'create organization'}

--- a/src/components/EditOrganization/EditOrganization.js
+++ b/src/components/EditOrganization/EditOrganization.js
@@ -28,14 +28,14 @@ export default function EditOrganization() {
   const [file, setFile] = useState()
   const [errors, setErrors] = useState([])
   const [showErrors, setShowErrors] = useState(false)
-  const [reloadForm, setReloadForm] = useState(true)
+  const [isInitialLoad, setIsInitialLoad] = useState(true)
 
   useEffect(() => {
-    if (org.name && !formData.name && reloadForm) {
+    if (org.name && !formData.name && isInitialLoad) {
+      setIsInitialLoad(false)
       initializeFormData(org, setFormData)
-      setReloadForm(false)
     }
-  }, [org, formData, reloadForm])
+  }, [org, formData, isInitialLoad])
 
   useEffect(() => {
     handleOrgIcon(org.icon, setOrgIconFullUrl)
@@ -179,7 +179,6 @@ export default function EditOrganization() {
         onClick={() => {
           handleSubmit()
           setShowErrors(true)
-          setReloadForm(false)
         }}
       >
         {id ? 'update organization' : 'create organization'}


### PR DESCRIPTION
Users can now delete form name entirely. 
![Sharing Excess _ Food Rescue and 5 more pages - Personal - Microsoft_ Edge 2021-01-20 11-56-21](https://user-images.githubusercontent.com/53373898/105208828-2353c500-5b17-11eb-8e80-c7622b9b56d9.gif)
