### PR TITLE
Philabundance Tags

### DIFF
--- a/src/components/EditLocation/EditLocation.js
+++ b/src/components/EditLocation/EditLocation.js
@@ -28,6 +28,7 @@ export default function EditLocation() {
     contact_name: '',
     contact_phone: '',
     upon_arrival_instructions: '',
+    is_philabundance_partner: '',
   })
   const [isPrimary, setIsPrimary] = useState(
     loc_id && organization ? organization.primary_location === loc_id : false
@@ -206,6 +207,24 @@ export default function EditLocation() {
               Make this the Organization's
               <br />
               Primary Address
+            </p>
+          </div>
+          <div className="is_philabundance_partner">
+            <input
+              type="checkbox"
+              id="is_philabundance_partner"
+              name="is_philabundance_partner"
+              checked={formData.is_philabundance_partner}
+              onChange={() =>
+                setFormData({
+                  ...formData,
+                  is_philabundance_partner: !formData.is_philabundance_partner,
+                })
+              }
+            />
+            <p>
+              Make this the Organization
+              <br />a Philabundance Partner
             </p>
           </div>
           <FormError />

--- a/src/components/EditLocation/EditLocation.scss
+++ b/src/components/EditLocation/EditLocation.scss
@@ -9,7 +9,8 @@
     margin-bottom: 8px;
   }
 
-  .is_primary {
+  .is_primary,
+  .is_philabundance_partner {
     opacity: 0;
     animation: slide-in 0.48s ease forwards;
     width: 100%;

--- a/src/components/EditLocation/utils.js
+++ b/src/components/EditLocation/utils.js
@@ -13,6 +13,9 @@ export function initializeFormData(location, callback) {
     upon_arrival_instructions: location.upon_arrival_instructions
       ? location.upon_arrival_instructions
       : '',
+    is_philabundance_partner: location.is_philabundance_partner
+      ? location.is_philabundance_partner
+      : '',
   })
 }
 

--- a/src/components/EditRoute/EditRoute.js
+++ b/src/components/EditRoute/EditRoute.js
@@ -223,6 +223,9 @@ function EditRoute() {
               ? `(${s.location.name})`
               : ''}
           </h2>
+          <p class="philabundance">
+            {s.location.is_philabundance_partner ? 'Philabundance Partner' : ''}
+          </p>
           <p>
             {s.location.address1}
             {s.location.address2 && ` - ${s.location.address2}`}

--- a/src/components/EditRoute/EditRoute.scss
+++ b/src/components/EditRoute/EditRoute.scss
@@ -169,6 +169,11 @@
       color: var(--blue);
       font-weight: 500;
       text-decoration: underline;
+
+      &.philabundance {
+        color: var(--yellow);
+        text-decoration: none;
+      }
     }
   }
 }

--- a/src/components/Organization/Organization.js
+++ b/src/components/Organization/Organization.js
@@ -48,6 +48,9 @@ function Organization() {
               {loc.id === org.primary_location && (
                 <i className="primary fa fa-star" />
               )}
+              {loc.is_philabundance_partner === true && (
+                <p className="philabundance">Philabundance Partner</p>
+              )}
               <p>{loc.address1}</p>
               {loc.address2 && <p>{loc.address2}</p>}
               <p>

--- a/src/components/Organization/Organization.scss
+++ b/src/components/Organization/Organization.scss
@@ -83,6 +83,13 @@
       color: var(--yellow);
     }
 
+    .philabundance {
+      position: absolute;
+      top: 36px;
+      right: 12px;
+      color: var(--yellow);
+    }
+
     h5 {
       font-size: 18px;
       margin-bottom: 4px;


### PR DESCRIPTION
Adding field to designate if a location is a Philabundance partner or not.

We'll need to do a bit more thinking on where to add filters for Philabundance partner locations -- as partnerships happen at the location level as opposed to an organization level (e.g. a particular Trader Joe's _locations_ may be Philabundance partners, but not all Trader Joe's _location_ are Philabundance partners)

![image](https://user-images.githubusercontent.com/19523341/105391690-fddebe00-5bdf-11eb-9df5-9fe5022f20de.png)

![image](https://user-images.githubusercontent.com/19523341/105391710-046d3580-5be0-11eb-88b7-1db350556823.png)
