### PR TITLE
fix: Input selection color

### DIFF
--- a/src/components/Input/Input.scss
+++ b/src/components/Input/Input.scss
@@ -67,6 +67,7 @@
       border-bottom: 4px solid var(--primary);
     }
   }
+  select option { background-color: var(--foreground); }
 
   input,
   textarea {


### PR DESCRIPTION
- Very small fix, but it's pretty important
- I fixed the dark mode route location problem by giving the selection background the foreground color
Pictures below show that it is now compatible with light/dark mode:
![image](https://user-images.githubusercontent.com/71650027/106198737-6ef31800-6182-11eb-8ac6-fb0965dc2f9a.png)
![image](https://user-images.githubusercontent.com/71650027/106198747-72869f00-6182-11eb-8796-ef5e25493f9a.png)
