### PR TITLE
Quick UI fix: relocate secondary phone

### DIFF
--- a/src/components/Route/Route.js
+++ b/src/components/Route/Route.js
@@ -610,6 +610,15 @@ function Route() {
                         )}
                       </p>
                     ) : null}
+                    {s.location.secondary_contact_phone ? (
+                      <p>
+                        <i className="fa fa-phone" />
+                        <a href={`tel:${s.location.secondary_contact_phone}`}>
+                          {formatPhoneNumber(s.location.contact_phone)}
+                        </a>
+                        <span>(Secondary)</span>
+                      </p>
+                    ) : null}
                     {s.location.time_open ? (
                       <p>
                         <i className="fa fa-clock-o" />
@@ -633,15 +642,6 @@ function Route() {
                         hours:{' '}
                         {moment(s.location.receive_start, 'hh:mm').format('LT')}{' '}
                         - {moment(s.location.receive_end, 'hh:mm').format('LT')}
-                      </p>
-                    ) : null}
-                    {s.location.secondary_contact_phone ? (
-                      <p>
-                        <i className="fa fa-phone" />
-                        <a href={`tel:${s.location.secondary_contact_phone}`}>
-                          {formatPhoneNumber(s.location.contact_phone)}
-                        </a>
-                        <span>(Secondary)</span>
                       </p>
                     ) : null}
                     <StopNotes stop={s} />


### PR DESCRIPTION
The secondary contact was moved after I merged my operation hours PR. I think it makes more sense to have two contacts next to each other, so here's a quick fix.

**Before:**
![image](https://user-images.githubusercontent.com/60493495/106424833-df26c580-6430-11eb-98e9-93f7f3e4bb09.png)

**After:**
![image](https://user-images.githubusercontent.com/60493495/106424861-f1086880-6430-11eb-916e-c8d2a151ea14.png)
