### PR TITLE
fix: Second history link

### DIFF
--- a/src/components/Menu/Menu.js
+++ b/src/components/Menu/Menu.js
@@ -81,9 +81,6 @@ function Menu() {
               <Link to="/history">History</Link>
             </li>
             <li onClick={() => dispatch(setMenu(false))}>
-              <Link to="/history">History</Link>
-            </li>
-            <li onClick={() => dispatch(setMenu(false))}>
               <Link to="/profile">Profile</Link>
             </li>
             <li onClick={() => dispatch(setMenu(false))}>


### PR DESCRIPTION
- Removed the second history link from the menu.
![image](https://user-images.githubusercontent.com/71650027/106484070-3d799580-647d-11eb-9139-38776b2c30e8.png)
