### PR TITLE
Adding history based routes for improved navigation, fixing CSS text …

### DIFF
--- a/src/components/Route/Route.js
+++ b/src/components/Route/Route.js
@@ -9,7 +9,7 @@ import {
 import Loading from '../Loading/Loading'
 import moment from 'moment'
 import UserIcon from '../../assets/user.svg'
-import { Link, useHistory, useParams } from 'react-router-dom'
+import { Link, useHistory, useLocation, useParams } from 'react-router-dom'
 import Ellipsis, { ExternalLink } from '../../helpers/components'
 import { generateDirectionsLink } from './utils'
 import { CLOUD_FUNCTION_URLS, ROUTE_STATUSES } from '../../helpers/constants'
@@ -37,6 +37,7 @@ function Route() {
   const deliveries = useDeliveryData()
   const organizations = useOrganizationData()
   const locations = useLocationData()
+  const location = useLocation()
   const [stops, setStops] = useState([])
   const [willCancel, setWillCancel] = useState()
   const [willComplete, setWillComplete] = useState()
@@ -375,7 +376,10 @@ function Route() {
     }
 
     function handleOpenReport() {
-      history.push(`/routes/${route_id}/${stop.type}/${stop.id}`)
+      const baseURL = location.pathname.includes('routes')
+        ? 'routes'
+        : 'history'
+      history.push(`/${baseURL}/${route_id}/${stop.type}/${stop.id}`)
     }
 
     if (route.status < 3) return null
@@ -451,7 +455,13 @@ function Route() {
       icon = <i id="StatusIndicator" className="fa fa-clock-o" />
     }
     return icon ? (
-      <Link to={`/routes/${route_id}/${stop.type}/${stop.id}`}>{icon}</Link>
+      <Link
+        to={`/${location.pathname.split('/')[1]}/${route_id}/${stop.type}/${
+          stop.id
+        }`}
+      >
+        {icon}
+      </Link>
     ) : null
   }
 

--- a/src/components/Route/Route.scss
+++ b/src/components/Route/Route.scss
@@ -193,7 +193,7 @@
         }
         .close {
           font-weight: 700;
-          color: var(--red)
+          color: var(--red);
         }
       }
 
@@ -237,13 +237,13 @@
       width: 100%;
       font-size: 18px;
       text-align: center;
-      color: var(--white);
+      color: var(--text);
     }
 
     > p {
       width: 100%;
       font-size: 14px;
-      color: var(--white);
+      color: var(--text);
       margin-top: 4px;
       text-align: center;
     }

--- a/src/components/Routes/Routes.js
+++ b/src/components/Routes/Routes.js
@@ -91,7 +91,14 @@ export default function Routes({ initial_filter }) {
         </div>
       ) : (
         filterAndSortRoutes(routes).map(r => (
-          <Link to={`/routes/${r.id}`} key={r.id}>
+          <Link
+            to={
+              location.pathname === '/routes'
+                ? `/routes/${r.id}`
+                : `/history/${r.id}`
+            }
+            key={r.id}
+          >
             <div
               className={`Route${
                 [0, 9].includes(r.status) && location.pathname === '/routes'

--- a/src/index.js
+++ b/src/index.js
@@ -91,6 +91,15 @@ function App() {
                 <Route exact path="/history">
                   <Routes initial_filter={r => [0, 9].includes(r.status)} />
                 </Route>
+                <Route exact path="/history/:route_id">
+                  <DriverRoute />
+                </Route>
+                <Route exact path="/history/:route_id/pickup/:pickup_id">
+                  <PickupReport />
+                </Route>
+                <Route exact path="/history/:route_id/delivery/:delivery_id">
+                  <DeliveryReport />
+                </Route>
                 <Route exact path="/routes/:route_id">
                   <DriverRoute />
                 </Route>
@@ -128,9 +137,6 @@ function App() {
                   {/* this 404 page component will render if the url does not match any other routes */}
                 </Route>
               </Switch>
-              <AdminPhoneNumber
-                text={'Have any questions? Call us at 1-833-742-7397'}
-              />
             </Firestore>
           </Auth>
         </BrowserRouter>


### PR DESCRIPTION
 - Adding history based routes for improved navigation (now if you click on a route from history, your URL will still include 'history' instead of 'routes', and the back button will take you back to 'history')
 - fixing CSS text color for additional dropoffs (was previously white on white, now uses `var(--text)` to use correct color based on light/dark mode)
 - removing 2nd footer for semantics and readability (contact phone number is still listed with a clickable link in the Help tab, but this prevents this text from overlapping other text, or the home pull tab bar on iOS)