### PR TITLE
Move "Other" field item on pickup report to bottom of the pickup report

### DIFF
--- a/src/components/PickupReport/PickupReport.js
+++ b/src/components/PickupReport/PickupReport.js
@@ -132,7 +132,15 @@ export default function PickupReport() {
       <Header text="Rescue Report" />
       <h3>{pickup_org.name}</h3>
       {Object.keys(formData)
-        .sort()
+        .sort(function (a, b) {
+          if (a === 'other') {
+            return 1
+          }
+          if (b === 'other') {
+            return -1
+          }
+          return a.localeCompare(b)
+        })
         .map(field =>
           !['weight', 'notes', 'created_at', 'updated_at'].includes(field) ? (
             <section key={field}>


### PR DESCRIPTION
Move "Other" field item on pickup report to bottom of the pickup report while keeping other field sorted alphabetically.
![image](https://user-images.githubusercontent.com/60493495/108495242-8bacd800-7276-11eb-99f1-7576ef7d7110.png)
