### PR TITLE
Feat: Priority sort routes if they're overdue

### DIFF
--- a/src/components/Routes/Routes.js
+++ b/src/components/Routes/Routes.js
@@ -54,15 +54,20 @@ export default function Routes({ initial_filter }) {
       ? routes
           .filter(r => r.driver_id === user.uid)
           .sort((a, b) => new Date(b.time_start) - new Date(a.time_start))
+          .sort((a, b) => new Date(a.time_start) - Date.now())
       : filter === 'incomplete'
       ? routes
           .filter(r => r.status === 1)
           .sort((a, b) => new Date(b.time_start) - new Date(a.time_start))
+          .sort((a, b) => new Date(a.time_start) - Date.now())
       : filter === 'happening'
       ? routes
           .filter(r => r.status === 3)
           .sort((a, b) => new Date(b.time_start) - new Date(a.time_start))
-      : routes.sort((a, b) => new Date(b.time_start) - new Date(a.time_start))
+          .sort((a, b) => new Date(a.time_start) - Date.now())
+      : routes
+          .sort((a, b) => new Date(b.time_start) - new Date(a.time_start))
+          .sort((a, b) => new Date(a.time_start) - Date.now())
   }
 
   function StatusIndicator({ route }) {


### PR DESCRIPTION
Very small addition. Evan asked that if a route is overdue, it should appear at the top of the list of routes, and then sorted by the soonest occurring route after all overdue routes are sorted to the top.

Conveniently, the data we have in dev made validating that sorting works as intended:
![image](https://user-images.githubusercontent.com/19523341/110534089-4d237400-80e4-11eb-993d-6f6dcfa1233a.png)
