### PR TITLE
Styling analytics

### DIFF
--- a/src/components/Analytics/Analytics.js
+++ b/src/components/Analytics/Analytics.js
@@ -69,7 +69,7 @@ export default function Analytics() {
 
   function RouteAnalytics() {
     return (
-      <table>
+      <table className="Analytics__Route">
         <thead>
           <tr>
             <td>Route ID</td>

--- a/src/components/Analytics/Analytics.js
+++ b/src/components/Analytics/Analytics.js
@@ -91,7 +91,7 @@ export default function Analytics() {
             return (
               <tr key={r.id}>
                 <td>{r.id}</td>
-                <td>{r_driver.name}</td>
+                <td id="driver">{r_driver.name}</td>
                 <td>
                   <ul>
                     {r_pickups.map(p => (
@@ -106,7 +106,7 @@ export default function Analytics() {
                     ))}
                   </ul>
                 </td>
-                <td>{r_weight}</td>
+                <td id="weight">{r_weight}</td>
               </tr>
             )
           })}

--- a/src/components/Analytics/Analytics.scss
+++ b/src/components/Analytics/Analytics.scss
@@ -48,12 +48,14 @@
       color: var(--primary);
     }
     td {
+      box-shadow: 0px 2px var(--lightgrey);
       padding: 4px;
       word-wrap: break-word;
       ul {
         padding-right: 8px;
         li {
           list-style-type: circle;
+          margin-bottom: 12px;
         }
       }
     }

--- a/src/components/Analytics/Analytics.scss
+++ b/src/components/Analytics/Analytics.scss
@@ -48,7 +48,6 @@
       color: var(--primary);
     }
     td {
-      box-shadow: 0px 2px var(--lightgrey);
       padding: 4px;
       word-wrap: break-word;
       ul {
@@ -58,6 +57,12 @@
           margin-bottom: 12px;
         }
       }
+    }
+  }
+
+  .Analytics__Route {
+    td {
+      border: 2px solid white;
     }
   }
 }

--- a/src/components/Analytics/Analytics.scss
+++ b/src/components/Analytics/Analytics.scss
@@ -64,5 +64,10 @@
     td {
       border: 2px solid white;
     }
+
+    #driver,
+    #weight {
+      text-align: center;
+    }
   }
 }

--- a/src/components/Analytics/Analytics.scss
+++ b/src/components/Analytics/Analytics.scss
@@ -53,7 +53,7 @@
       ul {
         padding-right: 8px;
         li {
-          list-style-type: circle;
+          list-style-type: none;
           margin-bottom: 12px;
         }
       }


### PR DESCRIPTION
I have added the grid for the Routes Analytics

1. Add the class name "Analytics__Route" to the right table
2. Add styling to give each cell its own border
3. Give the list item some margin to have more space so that it is easier to distinguish the items and understand
4. Remove the list items marker

![image](https://user-images.githubusercontent.com/58579187/113959663-e380ad80-97e8-11eb-9199-8e44de1d583e.png)
