### PR TITLE
Log pounds to completed routes

### DIFF
--- a/src/components/Route/Route.js
+++ b/src/components/Route/Route.js
@@ -72,14 +72,10 @@ function Route() {
   }, [route, pickups, deliveries, organizations, locations]) // eslint-disable-line react-hooks/exhaustive-deps
 
   function getDeliveryWeight() {
-    if (route?.status === 9) {
-      const myDelivery = deliveries.find(
-        deliveryRoute => deliveryRoute.route_id === route.id
-      )
-      return myDelivery ? myDelivery.report.weight : 0
-    } else {
-      return 0
-    }
+    const myDelivery = deliveries.find(
+      deliveryRoute => deliveryRoute.route_id === route.id
+    )
+    return myDelivery ? myDelivery.report.weight : 0
   }
 
   function isNextIncompleteStop(index) {
@@ -124,8 +120,8 @@ function Route() {
         />
         <div>
           <h3>
-            {route.driver ? route.driver.name : 'No assigned driver'} -{' '}
-            <span>{deliveryWeight} lbs.</span>
+            {route.driver ? route.driver.name : 'No assigned driver'}
+            {route.status === 9 && <span> - {deliveryWeight} lbs.</span>}
           </h3>
           <h4>{moment(route.time_start).format('dddd, MMMM D')}</h4>
           <h5>

--- a/src/components/Route/Route.js
+++ b/src/components/Route/Route.js
@@ -71,6 +71,17 @@ function Route() {
     route && route.stops && updateStops()
   }, [route, pickups, deliveries, organizations, locations]) // eslint-disable-line react-hooks/exhaustive-deps
 
+  function getDeliveryWeight() {
+    if (route?.status === 9) {
+      const myDelivery = deliveries.find(
+        deliveryRoute => deliveryRoute.route_id === route.id
+      )
+      return myDelivery ? myDelivery.report.weight : 0
+    } else {
+      return 0
+    }
+  }
+
   function isNextIncompleteStop(index) {
     if (
       stops[index].status === 9 ||
@@ -104,6 +115,7 @@ function Route() {
         time_started: firebase.firestore.FieldValue.serverTimestamp(),
       })
     }
+    const deliveryWeight = getDeliveryWeight()
     return (
       <div id="Driver">
         <img
@@ -111,7 +123,10 @@ function Route() {
           alt={route.driver ? route.driver.name : 'No assigned driver'}
         />
         <div>
-          <h3>{route.driver ? route.driver.name : 'No assigned driver'}</h3>
+          <h3>
+            {route.driver ? route.driver.name : 'No assigned driver'} -{' '}
+            <span>{deliveryWeight} lbs.</span>
+          </h3>
           <h4>{moment(route.time_start).format('dddd, MMMM D')}</h4>
           <h5>
             {moment(route.time_start).format('h:mma')} -{' '}

--- a/src/components/Route/Route.js
+++ b/src/components/Route/Route.js
@@ -75,7 +75,7 @@ function Route() {
     const myDelivery = deliveries.find(
       deliveryRoute => deliveryRoute.route_id === route.id
     )
-    return myDelivery ? myDelivery.report.weight : 0
+    return myDelivery ? myDelivery.report?.weight : 0
   }
 
   function isNextIncompleteStop(index) {

--- a/src/components/Routes/Routes.js
+++ b/src/components/Routes/Routes.js
@@ -32,6 +32,13 @@ export default function Routes({ initial_filter }) {
   const [filterByDate, setFilterByDate] = useState(false)
   const [filter, setFilter] = useState(admin ? 'all' : 'mine')
 
+  function getDeliveryWeight(routeId) {
+    const myDelivery = deliveries.find(
+      deliveryRoute => deliveryRoute.route_id === routeId
+    )
+    return myDelivery ? myDelivery.report?.weight : 0
+  }
+
   useEffect(() => {
     async function addData() {
       const full_data = []
@@ -203,7 +210,12 @@ export default function Routes({ initial_filter }) {
               )}
               <div>
                 <StatusIndicator route={r} />
-                <h2>{r.driver.name || 'Unassigned Route'}</h2>
+                <h2>
+                  {r.driver.name || 'Unassigned Route'}
+                  {r.status === 9 && (
+                    <span> - {getDeliveryWeight(r.id)} lbs.</span>
+                  )}
+                </h2>
                 <h4>{moment(r.time_start).format('dddd, MMMM Do')}</h4>
                 <h5>
                   {moment(r.time_start).format('h:mma')} -{' '}


### PR DESCRIPTION
I have added the feature to log the pounds for the list of routes and the route also as long as the route is finished (aka. status of 9)

1. Retrieve the weight based on the route id and route status
2. Render it next to the driver's name (same for the list of Routes or the Route itself)
![image](https://user-images.githubusercontent.com/58579187/115275104-02474400-a107-11eb-9a16-8defb0f770dc.png)
![image](https://user-images.githubusercontent.com/58579187/115275139-0f643300-a107-11eb-9c95-2ed8ce9060e1.png)
![image](https://user-images.githubusercontent.com/58579187/115275182-1be88b80-a107-11eb-8411-b5c6097c5393.png)
