### PR TITLE
remove the logic for the date filter

### DIFF
--- a/src/components/Analytics/Analytics.js
+++ b/src/components/Analytics/Analytics.js
@@ -22,26 +22,8 @@ export default function Analytics() {
           new Date(r.time_start) < new Date(rangeEnd)
       : r => r.status === 9
   )
-  const deliveries = useDeliveryData(
-    rangeStart && rangeEnd
-      ? r =>
-          r.status === 9 &&
-          r.report &&
-          r.report.updated_at &&
-          r.report.updated_at.toDate() > new Date(rangeStart) &&
-          r.report.updated_at.toDate() < new Date(rangeEnd)
-      : r => r.status === 9
-  )
-  const pickups = usePickupData(
-    rangeStart && rangeEnd
-      ? r =>
-          r.status === 9 &&
-          r.report &&
-          r.report.updated_at &&
-          r.report.updated_at.toDate() > new Date(rangeStart) &&
-          r.report.updated_at.toDate() < new Date(rangeEnd)
-      : r => r.status === 9
-  )
+  const deliveries = useDeliveryData(r => r.status === 9 && r.report)
+  const pickups = usePickupData(r => r.status === 9 && r.report)
 
   function sortByRoutes(array) {
     return array.sort((a, b) =>


### PR DESCRIPTION
What is wrong with the logic and what I have done?

1. We have the bugs because we filter the deliveries and pickups by the updated_at time. This causes the bugs before somehow in testing, we finish the report even before the route start, then we filter the date ranges which is close to the start time of the route but that range will absolutely not containing the deliveries or pickups data
2. For now, I just suggest removing that filtering logic based on the updated_at time for deliveries and pickups and just focus on filtering the routes based on the time range input.
3. Later on, if we implement the features to hide the route from the driver until the start date, we can go back and consider adding the updated_at time logic