### PR TITLE
Feat/hide routes until start date

### DIFF
--- a/src/components/Routes/Routes.js
+++ b/src/components/Routes/Routes.js
@@ -84,6 +84,11 @@ export default function Routes({ initial_filter }) {
     console.log(routes.map(r => r.time_start.substring(0, 10)))
   }
   function filterAndSortRoutes(routes) {
+    // filter routes by date before rendering them
+    const routesToDisplay = admin
+      ? routes
+      : routes.filter(route => new Date(route.time_start) <= new Date())
+
     return filter === 'mine'
       ? routes
           .filter(r => r.driver_id === user.uid)

--- a/src/components/Routes/Routes.js
+++ b/src/components/Routes/Routes.js
@@ -90,27 +90,27 @@ export default function Routes({ initial_filter }) {
       : routes.filter(route => new Date(route.time_start) <= new Date())
 
     return filter === 'mine'
-      ? routes
+      ? routesToDisplay
           .filter(r => r.driver_id === user.uid)
           .sort((a, b) => new Date(b.time_start) - new Date(a.time_start))
           .sort((a, b) => new Date(a.time_start) - Date.now())
       : filter === 'unassigned'
-      ? routes
+      ? routesToDisplay
           .filter(r => r.driver.name === undefined)
           .sort((a, b) => new Date(b.time_start) - new Date(a.time_start))
           .sort((a, b) => new Date(a.time_start) - Date.now())
       : filter === 'incomplete'
-      ? routes
+      ? routesToDisplay
           .filter(r => r.status === 1)
           .sort((a, b) => new Date(b.time_start) - new Date(a.time_start))
           .sort((a, b) => new Date(a.time_start) - Date.now())
       : filter === 'happening'
-      ? routes
+      ? routesToDisplay
           .filter(r => r.status === 3)
           .sort((a, b) => new Date(b.time_start) - new Date(a.time_start))
           .sort((a, b) => new Date(a.time_start) - Date.now())
       : filter === 'driver'
-      ? routes
+      ? routesToDisplay
           .filter(
             r =>
               r.driver.name !== undefined &&
@@ -119,11 +119,11 @@ export default function Routes({ initial_filter }) {
           .sort((a, b) => new Date(b.time_start) - new Date(a.time_start))
           .sort((a, b) => new Date(a.time_start) - Date.now())
       : filter === 'date'
-      ? routes
+      ? routesToDisplay
           .filter(r => r.time_start.substring(0, 10) === searchByDate)
           .sort((a, b) => new Date(b.time_start) - new Date(a.time_start))
           .sort((a, b) => new Date(a.time_start) - Date.now())
-      : routes
+      : routesToDisplay
           .sort((a, b) => new Date(b.time_start) - new Date(a.time_start))
           .sort((a, b) => new Date(a.time_start) - Date.now())
   }


### PR DESCRIPTION
1. Create a filter for routes that have to be earlier than the current date and time
2. Only hide the routes from the user, not the admin
![demo_hide_routes_until_start_date](https://user-images.githubusercontent.com/58579187/116723480-33483400-a9a5-11eb-80fc-3c8f7d5c1ec1.gif)
