### PR TITLE
Created typeable input boxes in Pickup Report

### DIFF
--- a/src/components/EditRoute/EditRoute.js
+++ b/src/components/EditRoute/EditRoute.js
@@ -452,7 +452,7 @@ function EditRoute() {
                         <Ellipsis />
                       </>
                     ) : (
-                      'complete'
+                      'create route'
                     )}
                   </button>
                 )}

--- a/src/components/PickupReport/PickupReport.js
+++ b/src/components/PickupReport/PickupReport.js
@@ -85,6 +85,21 @@ export default function PickupReport() {
     if (formData.weight <= 0) {
       errors.push('Invalid Input: Total Weight must be greater than zero')
     }
+    if (
+      !validator.isInt(
+        formData.dairy ||
+          formData.bakery ||
+          formData.produce ||
+          formData['meat/Fish'] ||
+          formData['non-perishable'] ||
+          formData['prepared/Frozen'] ||
+          formData['mixed groceries'] ||
+          formData.other
+      )
+    ) {
+      errors.push('Invalid Input: Item Weight must be a whole number')
+      return false
+    }
     if (errors.length === 0) {
       return true
     }
@@ -153,9 +168,10 @@ export default function PickupReport() {
               ) : null}
               <input
                 id={field}
-                type="number"
+                type="string"
                 value={formData[field]}
                 onChange={handleChange}
+                readOnly={!canEdit()}
               />
               {canEdit() ? (
                 <button className="increment" onClick={() => increment(field)}>

--- a/src/components/PickupReport/PickupReport.js
+++ b/src/components/PickupReport/PickupReport.js
@@ -10,6 +10,7 @@ import useOrganizationData from '../../hooks/useOrganizationData'
 import { useAuthContext } from '../Auth/Auth'
 import './PickupReport.scss'
 import Header from '../Header/Header'
+import validator from 'validator'
 
 export default function PickupReport() {
   const { pickup_id, route_id } = useParams()
@@ -151,9 +152,8 @@ export default function PickupReport() {
                 </button>
               ) : null}
               <input
-                readOnly
                 id={field}
-                type="tel"
+                type="number"
                 value={formData[field]}
                 onChange={handleChange}
               />


### PR DESCRIPTION
1. When creating new route, changed the blue button to say "create route" instead of "complete" for more clarity
2. When completing Pickup Report, user can type numerical input instead of only using +/- buttons
![image](https://user-images.githubusercontent.com/63413560/118136684-6097d780-b3d2-11eb-81a0-943a2e475290.png)

Issue: There are tiny arrows inside of the input box. I think they look sort of ugly and I'm not sure how to get rid of them

Update:
1. Validated user input for item weight in Pickup Report to accept only integers/whole numbers
2. Validates each input when user presses "submit report" button
3. If decimal input, displays "Invalid input: Item Weight must be a whole number" after pressing submit report button
4. I fixed the tiny ugly arrows in the input boxes
![image](https://user-images.githubusercontent.com/63413560/118143075-f5053880-b3d8-11eb-841e-733e32d11963.png)

