### PR TITLE
fix: cancel stops logic complete

### DIFF
--- a/src/components/Route/utils.js
+++ b/src/components/Route/utils.js
@@ -9,12 +9,11 @@ export function allFoodDelivered(stops) {
   }
   let finalWeight = 0
   for (const stop of stops) {
-    if (!stop.report) {
-      return false
+    if (stop.report?.weight) {
+      stop.type === 'pickup'
+        ? (finalWeight += stop.report.weight)
+        : (finalWeight -= stop.report.weight)
     }
-    stop.type === 'pickup'
-      ? (finalWeight += stop.report.weight)
-      : (finalWeight -= stop.report.weight)
   }
   return finalWeight === 0
 }
@@ -23,7 +22,7 @@ export function areAllStopsCompleted(stops) {
   let completed = true
   for (const s of stops) {
     // if stop is not completed or cancelled
-    if (s.status === 1) {
+    if (s.status !== 0 && s.status !== 9) {
       completed = false
       break
     }


### PR DESCRIPTION
For now, as long as all stops are either complete or canceled and all food weight is delivered, the 
driver can finish route (no need to delete stops)

![cancel-logic](https://user-images.githubusercontent.com/58579187/126583977-20d1a1b1-6b67-4f52-98df-d06133cdff32.gif)