### PR TITLE
Reformat 'edit stops' button so that it has the same width as other buttons

### DIFF
--- a/src/components/Route/Route.js
+++ b/src/components/Route/Route.js
@@ -794,11 +794,12 @@ export function Route() {
               {(route.status === 1 || route.status === 3) &&
                 route.driver &&
                 admin && (
-                  <div>
-                    <Link to={`/routes/${route.id}/edit`}>
-                      <button>Edit Stops</button>
+                  <button>
+                    <Link to={`/routes/${route.id}/edit`} className="link">
+                      Edit Stops
                     </Link>
-                  </div>
+                  </button>
+
                 )}
               <StatusButton />
               {admin === true ? <CancelButton /> : null}

--- a/src/components/Route/Route.js
+++ b/src/components/Route/Route.js
@@ -794,12 +794,9 @@ export function Route() {
               {(route.status === 1 || route.status === 3) &&
                 route.driver &&
                 admin && (
-                  <button>
-                    <Link to={`/routes/${route.id}/edit`} className="link">
-                      Edit Stops
-                    </Link>
-                  </button>
-
+                  <Link to={`/routes/${route.id}/edit`} className="buttons">
+                    <button>Edit Stops</button>
+                  </Link>
                 )}
               <StatusButton />
               {admin === true ? <CancelButton /> : null}

--- a/src/components/Route/Route.scss
+++ b/src/components/Route/Route.scss
@@ -8,10 +8,7 @@
     text-transform: capitalize;
   }
 
-  a {
-    color: var(--blue);
-    text-decoration: underline;
-  }
+  
   button {
     width: 100%;
     margin-top: 12px;


### PR DESCRIPTION
**Before:** 
![image](https://user-images.githubusercontent.com/60908199/129963877-15eeabe1-0980-4b9e-a997-3fe78286c97c.png)
**After:**
 ![image](https://user-images.githubusercontent.com/60908199/129963805-52841638-c35b-4e7f-8280-58816a7a27a2.png)
