### PR TITLE
Removed the "Force Finish Route" Duplicate

### DIFF
--- a/src/components/Route/Route.children.js
+++ b/src/components/Route/Route.children.js
@@ -74,6 +74,19 @@ export function RouteMenu() {
   const { setModal, modalState } = useApp()
   const { user, admin } = useAuth()
 
+  function RouteOption(props) {
+    return (
+      <Button
+        type="tertiary"
+        color="blue"
+        size="large"
+        handler={() => setModal(props.modalName)}
+      >
+        {props.name}
+      </Button>
+    )
+  }
+
   return (
     <div id="RouteMenu">
       <Text type="secondary-header" color="black">
@@ -81,68 +94,51 @@ export function RouteMenu() {
       </Text>
       <Spacer height={8} />
       <ul>
+        {user.id === modalState.route.driver_id || admin ? (
+          <>
+            <li>
+              <RouteOption 
+                modalName="FinishRoute" 
+                name="Force Finish Route"
+              />
+            </li>
+          </>
+        ) : null}
+
         {user.id === modalState.route.driver_id ? (
           <>
             <li>
-              <Button
-                type="tertiary"
-                color="blue"
-                size="large"
-                handler={() => setModal('FinishRoute')}
-              >
-                Force Finish Route
-              </Button>
+              <RouteOption 
+                modalName="DropRoute" 
+                name="Drop Route" 
+              />
             </li>
             <li>
-              <Button
-                type="tertiary"
-                color="blue"
-                size="large"
-                handler={() => setModal('DropRoute')}
-              >
-                Drop Route
-              </Button>
-            </li>
-            <li>
-              <Button
-                type="tertiary"
-                color="blue"
-                size="large"
-                handler={() => setModal('ContactAdmin')}
-              >
-                Contact Admin
-              </Button>
+              <RouteOption 
+                modalName="ContactAdmin" 
+                name="Contact Admin" 
+              />
             </li>
           </>
         ) : null}
         {admin ? (
           <>
             <li>
-              <Button
-                type="tertiary"
-                color="blue"
-                size="large"
-                handler={() => setModal('FinishRoute')}
-              >
-                Force Finish Route
-              </Button>
-            </li>
-            <li>
               <Link to={`/routes/${modalState.route.id}/edit`}>
-                <Button type="tertiary" color="blue" size="large">
+                <Button 
+                  type="tertiary" 
+                  color="blue" 
+                  size="large"
+                >
                   Edit Route
                 </Button>
               </Link>
             </li>
             <li>
-              <Button
-                type="tertiary"
-                color="blue"
-                size="large"
-                handler={() => setModal('CancelRoute')}
-              >
-                Cancel Route
-              </Button>
+              <RouteOption 
+                modalName="CancelRoute" 
+                name="Cancel Route" 
+              />
             </li>
           </>
         ) : null}


### PR DESCRIPTION
### Type of PR 
Bug, Frontend

### Description
Armando fixed the bug where "Force Finish Route" came up twice in the menu, which happened for any admin that was also a driver for route. Armando also created a functional component within the RouteMenu component, RouteOption, to be reused for the options.

### Screenshots

![image](https://user-images.githubusercontent.com/78700199/137948277-b5d26f8b-9384-4ef7-a569-c01340069246.png)

![image](https://user-images.githubusercontent.com/78700199/137948378-4e4c52de-a679-4785-b4d7-b1b77405da65.png)

