### PR TITLE
Made header fixed when scrolling

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -47,7 +47,7 @@ export function Header() {
           {path_components.length > 0 ? (
             <Link to={back_url}>
               <Button
-                type="tertiary"
+                type="primary"
                 size="small"
                 color="white"
                 id="Header-back-link"
@@ -60,6 +60,7 @@ export function Header() {
         {isMobile ? <UserProfile /> : null}
       </header>
       <Menu isOpen={menuOpen} setIsOpen={setMenuOpen} />
+      
     </>
   )
 }

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -1,5 +1,5 @@
 header#Header {
-  position: absolute;
+  position: fixed;
   top: 0;
   @media all and (display-mode: standalone) {
     top: 48px;
@@ -13,6 +13,10 @@ header#Header {
   animation: fade-in 0.32s ease forwards;
   z-index: 20;
   transition: all 0.2s ease;
+
+  @media only screen and (max-device-width: 480px) {
+    background: linear-gradient( to top right, rgba(123, 218, 83, 1), rgba(62, 113, 40, 1) );
+  }
 
   @include desktop {
     padding: 32px;


### PR DESCRIPTION
I have made the header fixed by changing `position: absolute` to `position: fixed`.  I also added background color for the header so that we the page is scrolled, it's easier for us to see text and buttons. However, I ran into a small problem. Since the page's background is gradient green, it's hard to blend the header block with the rest of the page, especially with pages that are not scrollable or have little content (For example: Home page, New Route, New Direct Donation) (Check out the video attached)
https://user-images.githubusercontent.com/60908199/139201644-7f0e47cf-6654-4b15-a8b5-60251ff17666.mp4

