### PR TITLE
Removed the Weight From Ongoing Routes

### DIFF
--- a/src/components/Routes/Routes.js
+++ b/src/components/Routes/Routes.js
@@ -142,9 +142,13 @@ export function Routes({ initial_filter }) {
 
   function generateStopLabel(stop) {
     if (stop.status === 0) {
-      return `${stop.org.name} (${stop.location.name || stop.location.address1}) - Cancelled`
+      return `${stop.org.name} (${
+        stop.location.name || stop.location.address1
+      }) - Cancelled`
     } else {
-      return `${stop.org.name} (${stop.location.name || stop.location.address1})`
+      return `${stop.org.name} (${
+        stop.location.name || stop.location.address1
+      })`
     }
   }
 
@@ -153,7 +157,7 @@ export function Routes({ initial_filter }) {
       return `${delivery.org.name} (${
         delivery.location.name || delivery.location.address1
       }) - Cancelled`
-    } else {
+    } else if (delivery.status === 9) {
       if (delivery.report) {
         if (delivery.report.weight) {
           return `${delivery.org.name} (${
@@ -169,6 +173,10 @@ export function Routes({ initial_filter }) {
           delivery.location.name || delivery.location.address1
         }) - 0 lbs.`
       }
+    } else {
+      return `${delivery.org.name} (${
+        delivery.location.name || delivery.location.address1
+      })`
     }
   }
 


### PR DESCRIPTION
# Description
Ongoing routes would show weight for deliveries when they were not completed, so it would say 0 lbs. I removed this so that ongoing routes would not display the weight.

# Screenshots

## Before
![image](https://user-images.githubusercontent.com/78700199/139321295-a0d51735-8d52-49a8-a517-281273b88989.png)

## After
![image](https://user-images.githubusercontent.com/78700199/139321368-36e6eb59-907c-4984-88fd-6ea9c6c77b9a.png)
