### PR TITLE
shadows for headers of current and past routes

### DIFF
--- a/src/components/Routes/Routes.js
+++ b/src/components/Routes/Routes.js
@@ -142,11 +142,13 @@ export function Routes({ initial_filter }) {
 
   return routes ? (
     <main id="Routes">
-      <Text type="section-header" color="white" align="center">
-        {location.pathname === '/routes'
-          ? 'Viewing Current Routes'
-          : 'Viewing Past Routes'}
-      </Text>
+      <div className='routesHeader'>
+        <Text type="section-header" color="white" align="center">
+          {location.pathname === '/routes'
+            ? 'Viewing Current Routes'
+            : 'Viewing Past Routes'}
+        </Text>
+      </div>
       <Spacer height={32} />
       <section id="Filters">
         <select

--- a/src/components/Routes/Routes.js
+++ b/src/components/Routes/Routes.js
@@ -142,13 +142,11 @@ export function Routes({ initial_filter }) {
 
   return routes ? (
     <main id="Routes">
-      <div className='routesHeader'>
-        <Text type="section-header" color="white" align="center">
-          {location.pathname === '/routes'
-            ? 'Viewing Current Routes'
-            : 'Viewing Past Routes'}
-        </Text>
-      </div>
+      <Text type="section-header" color="white" align="center" shadow>
+        {location.pathname === '/routes'
+          ? 'Viewing Current Routes'
+          : 'Viewing Past Routes'}
+      </Text>
       <Spacer height={32} />
       <section id="Filters">
         <select
@@ -256,7 +254,7 @@ export function Routes({ initial_filter }) {
                 </div>
                 <Spacer height={12} />
                 <Text type="small" color="grey" classList={['pickups']}>
-                🟩{'  '}
+                  🟩{'  '}
                   {r.stops
                     .filter(s => s.type === 'pickup')
                     .map(
@@ -269,7 +267,7 @@ export function Routes({ initial_filter }) {
                 </Text>
                 <Spacer height={8} />
                 <Text type="small" color="grey" classList={['deliveries']}>
-                🟥{'  '}
+                  🟥{'  '}
                   {r.stops
                     .filter(s => s.type === 'delivery')
                     .map(

--- a/src/components/Routes/Routes.scss
+++ b/src/components/Routes/Routes.scss
@@ -16,6 +16,10 @@
     width: 100%;
   }
 
+  .routesHeader {
+    text-shadow:  var(--se-shadow-medium);
+  }
+
   #Filters {
     display: flex;
     justify-content: space-between;

--- a/src/components/Routes/Routes.scss
+++ b/src/components/Routes/Routes.scss
@@ -16,10 +16,6 @@
     width: 100%;
   }
 
-  .routesHeader {
-    text-shadow:  var(--se-shadow-medium);
-  }
-
   #Filters {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
 I added shadows to the headers of the routes and history pages, I tried hard coding it into the JavaScript code but it wasn't working for some reason so I created a div and styled with CSS. See the screenshots of the code and the before and after picture below:
![Screenshot 2021-11-03 193400](https://user-images.githubusercontent.com/91069165/140236335-0b5781d0-c17a-40e9-9edb-5c386d9bc84b.png)
![Screenshot 2021-11-03 192953](https://user-images.githubusercontent.com/91069165/140236334-cb270ff9-c165-4a14-9dfa-0e28a3e62db8.png)
![Screenshot 2021-11-03 193930](https://user-images.githubusercontent.com/91069165/140236336-a37bfc59-a986-4484-a7ad-7c2bb88cc93c.png)
![Screenshot 2021-11-03 194200](https://user-images.githubusercontent.com/91069165/140236337-a14c6bd3-3ecd-4e1d-af46-07f951b5bde1.png)
![Screenshot 2021-11-03 194246](https://user-images.githubusercontent.com/91069165/140236339-32192ed0-a6b7-44d4-9351-fc4a9eaf77e1.png)
