### PR TITLE
Implemented query param to open Route previews (History tab) in a new tab

### DIFF
--- a/src/components/Routes/Routes.js
+++ b/src/components/Routes/Routes.js
@@ -26,15 +26,24 @@ export function Routes({ initial_filter }) {
   const [filterByDriver, setFilterByDriver] = useState(false)
   const [filterByDate, setFilterByDate] = useState(false)
   const [filter, setFilter] = useState(admin ? 'all' : 'mine')
+  const [isInitialRender, setIsInitialRender] = useState(true)
 
   useEffect(() => {
     // check if there are any "filter" query params
     // if there are, then setFilter("that parameter")
-    const filterSearchParam = new URLSearchParams(window.location.search).get(
-      'filter'
-    )
+
+    let searchParams = new URLSearchParams(window.location.search)
+    const filterSearchParam = searchParams.get('filter')
     if (filterSearchParam) {
       setFilter(filterSearchParam)
+    }
+    const driverSearchParam = searchParams.get('driver')
+    if (driverSearchParam) {
+      setSearchByDriver(driverSearchParam)
+    }
+    const dateSearchParam = searchParams.get('date')
+    if (dateSearchParam) {
+      setSearchByDate(dateSearchParam)
     }
   }, [])
 
@@ -83,18 +92,31 @@ export function Routes({ initial_filter }) {
   ])
 
   useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
     if (filter === 'driver') {
-      history.replace('history?filter=driver')
+      params.set('filter', 'driver')
+      if (searchByDriver) {
+        params.set('driver', searchByDriver)
+      }
+      params.delete('date')
+      history.replace(`/history?${params.toString()}`)
       setFilterByDriver(true)
       setFilterByDate(false)
     } else if (filter === 'date') {
-      history.replace('history?filter=date')
+      params.set('filter', 'date')
+      if (searchByDate) {
+        params.set('date', searchByDate)
+      }
+      params.delete('driver')
+      history.replace(`/history?${params.toString()}`)
       setFilterByDriver(false)
       setFilterByDate(true)
     } else if (filter === 'mine') {
       history.replace('history?filter=mine')
     } else if (filter === 'unassigned') {
       history.replace('history?filter=unassigned')
+    } else if (isInitialRender) {
+      setIsInitialRender(false)
     } else {
       history.replace('history')
       setFilterByDriver(false)
@@ -104,10 +126,13 @@ export function Routes({ initial_filter }) {
 
   function handleSearchByDriver(e) {
     setSearchByDriver(e.target.value)
+    history.replace(`history?filter=driver&driver=${e.target.value}`)
   }
   function handleSearchByDate(e) {
     setSearchByDate(e.target.value)
+    history.replace(`history?filter=date&date=${e.target.value}`)
   }
+
   function filterAndSortRoutes(routes) {
     return filter === 'mine'
       ? routes

--- a/src/components/Routes/Routes.js
+++ b/src/components/Routes/Routes.js
@@ -3,11 +3,12 @@ import { getImageFromStorage, isValidURL } from 'helpers'
 import { Input, Loading } from 'components'
 import moment from 'moment'
 import UserIcon from 'assets/user.svg'
-import { Link, useLocation } from 'react-router-dom'
+import { Link, useLocation, useHistory } from 'react-router-dom'
 import { useAuth, useFirestore } from 'hooks'
 import { Button, Card, Spacer, Text } from '@sharingexcess/designsystem'
 
 export function Routes({ initial_filter }) {
+  const history = useHistory()
   const { user, admin } = useAuth()
   const locations = useFirestore('locations')
   const location = useLocation()
@@ -25,6 +26,17 @@ export function Routes({ initial_filter }) {
   const [filterByDriver, setFilterByDriver] = useState(false)
   const [filterByDate, setFilterByDate] = useState(false)
   const [filter, setFilter] = useState(admin ? 'all' : 'mine')
+
+  useEffect(() => {
+    // check if there are any "filter" query params
+    // if there are, then setFilter("that parameter")
+    const filterSearchParam = new URLSearchParams(window.location.search).get(
+      'filter'
+    )
+    if (filterSearchParam) {
+      setFilter(filterSearchParam)
+    }
+  }, [])
 
   function getRouteWeight(routeId) {
     const deliveredWeight = deliveries.filter(r => r.route_id === routeId)
@@ -72,16 +84,24 @@ export function Routes({ initial_filter }) {
 
   useEffect(() => {
     if (filter === 'driver') {
+      history.replace('history?filter=driver')
       setFilterByDriver(true)
       setFilterByDate(false)
     } else if (filter === 'date') {
+      history.replace('history?filter=date')
       setFilterByDriver(false)
       setFilterByDate(true)
+    } else if (filter === 'mine') {
+      history.replace('history?filter=mine')
+    } else if (filter === 'unassigned') {
+      history.replace('history?filter=unassigned')
     } else {
+      history.replace('history')
       setFilterByDriver(false)
       setFilterByDate(false)
     }
-  }, [filter])
+  }, [filter]) // eslint-disable-line
+
   function handleSearchByDriver(e) {
     setSearchByDriver(e.target.value)
   }


### PR DESCRIPTION
Drivers now can refresh a route preview page without worrying the filter or search bar being wiped off.
https://user-images.githubusercontent.com/60908199/140586214-c51a6ee8-7401-48b7-8c15-a661430252b7.mp4

