### PR TITLE
Bug/horizontal axis label

### DIFF
--- a/src/components/Analytics/Analytics.js
+++ b/src/components/Analytics/Analytics.js
@@ -168,18 +168,22 @@ export function Analytics() {
     return null
   }
 
-  const CustomAxisTick = ({ x, y, stroke, payload }) => {
+  const CustomXAxisTick = ({ x, y, payload }) => {
     return (
       <g transform={`translate(${x},${y})`}>
         <text
           x={0}
           y={0}
           dy={16}
+          fill="var(--se-grey-dark)"
+          transform="rotate(-40)"
+          width={5}
           textAnchor="end"
-          fill="#666"
-          transform="rotate(-60)"
+          verticalAnchor="middle"
+          scaleToFit={true}
         >
-          {payload.value}
+          {payload.value.substring(0, 13)}
+          {payload.value.length >= 13 ? '...' : ''}
         </text>
       </g>
     )
@@ -263,31 +267,32 @@ export function Analytics() {
           </FlexContainer>
           <Spacer height={32} />
           <section className="PoundsInDateRange-graph">
-            <ResponsiveContainer width="100%" height={300}>
+            <ResponsiveContainer width="100%" height={500}>
               {chart === 'Bar Chart' ? (
                 <BarChart
                   width={300}
                   height={300}
                   data={graphData}
-                  margin={{ top: 20, bottom: 10 }}
+                  margin={{ top: 20, bottom: 96, right: 20 }}
                 >
                   <XAxis
                     dataKey="name"
-                    scaleToFit={true}
                     interval={0}
                     allowDataOverflow={false}
-                    tick={<CustomAxisTick />}
-                  />
+                    tick={<CustomXAxisTick />}
+                    height={0.1}
+                    tickSize={25}
+                  ></XAxis>
                   <YAxis tickFormatter={num => shortenLargeNumber(num)} />
                   <Tooltip content={<CustomTooltip />} />
                   <Bar dataKey="value" fill="var(--primary)" barSize={30} />
                   <Brush
                     dataKey="name"
                     height={20}
-                    stroke="var(--se-grey-dark )"
+                    stroke="var(--se-grey-primary)"
                     travellerWidth={0}
                     startIndex={0}
-                    endIndex={5}
+                    endIndex={7}
                   />
                 </BarChart>
               ) : chart === 'Pie Chart' ? (

--- a/src/components/Analytics/Analytics.js
+++ b/src/components/Analytics/Analytics.js
@@ -9,6 +9,7 @@ import {
   Tooltip,
   Legend,
   ResponsiveContainer,
+  Brush,
   PieChart,
   Pie,
   Cell,
@@ -167,6 +168,23 @@ export function Analytics() {
     return null
   }
 
+  const CustomAxisTick = ({ x, y, stroke, payload }) => {
+    return (
+      <g transform={`translate(${x},${y})`}>
+        <text
+          x={0}
+          y={0}
+          dy={16}
+          textAnchor="end"
+          fill="#666"
+          transform="rotate(-60)"
+        >
+          {payload.value}
+        </text>
+      </g>
+    )
+  }
+
   return (
     <main id="Analytics">
       <FlexContainer className="InputSection" primaryAlign="space-between">
@@ -253,10 +271,24 @@ export function Analytics() {
                   data={graphData}
                   margin={{ top: 20, bottom: 10 }}
                 >
-                  <XAxis dataKey="name" scaleToFit={true} interval={0} />
+                  <XAxis
+                    dataKey="name"
+                    scaleToFit={true}
+                    interval={0}
+                    allowDataOverflow={false}
+                    tick={<CustomAxisTick />}
+                  />
                   <YAxis tickFormatter={num => shortenLargeNumber(num)} />
                   <Tooltip content={<CustomTooltip />} />
                   <Bar dataKey="value" fill="var(--primary)" barSize={30} />
+                  <Brush
+                    dataKey="name"
+                    height={20}
+                    stroke="var(--se-grey-dark )"
+                    travellerWidth={0}
+                    startIndex={0}
+                    endIndex={5}
+                  />
                 </BarChart>
               ) : chart === 'Pie Chart' ? (
                 <PieChart width={400} height={400}>


### PR DESCRIPTION
To add a horizontal scroll bar for the chart, I've used a Recharts component called `Brush` (https://recharts.org/en-US/api/Brush). Originally, `Brush` has a window that's resizeable depending on the range of data that users want. However, I've made that window fixed in one range, which makes the UI more consistent and easier for users.
`<Brush
                    dataKey="name"
                    height={20}
                    stroke="var(--se-grey-primary)"
                    travellerWidth={0}
                    startIndex={0}
                    endIndex={7}
                  />`

![image](https://user-images.githubusercontent.com/60908199/154998549-d0c76184-e150-4b22-8dc4-4ef721884aa4.png)
