### PR TITLE
Deleted Orgs Appeared When Scheduling a Rescue

### DIFF
--- a/src/components/EditDelivery/EditDelivery.js
+++ b/src/components/EditDelivery/EditDelivery.js
@@ -86,6 +86,7 @@ export function EditDelivery({ handleSubmit, title }) {
           field
         )
       }
+
       return (
         <Input
           key={field.id}

--- a/src/components/EditDelivery/EditDelivery.js
+++ b/src/components/EditDelivery/EditDelivery.js
@@ -8,7 +8,7 @@ import { generateUniqueId } from 'helpers'
 export function EditDelivery({ handleSubmit, title }) {
   const recipients = useFirestore(
     'organizations',
-    useCallback(i => i.type === 'recipient', [])
+    useCallback(i => i.type === 'recipient' && !i.is_deleted, [])
   )
   const locations = useFirestore(
     'locations',
@@ -86,7 +86,6 @@ export function EditDelivery({ handleSubmit, title }) {
           field
         )
       }
-
       return (
         <Input
           key={field.id}

--- a/src/components/EditPickup/EditPickup.js
+++ b/src/components/EditPickup/EditPickup.js
@@ -8,7 +8,7 @@ import { generateUniqueId } from 'helpers'
 export function EditPickup({ handleSubmit, title }) {
   const donors = useFirestore(
     'organizations',
-    useCallback(i => i.type === 'donor', [])
+    useCallback(i => i.type === 'donor' && !i.is_deleted, [])
   )
   const locations = useFirestore(
     'locations',


### PR DESCRIPTION
A second organization called "Feast of Justice" was created and deleted, but this deleted org still appeared as an option when scheduling a rescue. When getting the recipients from firebase, a filter was added to check that the recipient did not have a field called "is_deleted."

Before
---
![image](https://user-images.githubusercontent.com/78700199/156448695-9b72d212-2b39-4d0d-bfbf-b817fd0cde2d.png)

After
---
![image](https://user-images.githubusercontent.com/78700199/156448580-ef27f662-e385-4edd-973b-6847f95aa698.png)
