### PR TITLE
Feat/add instructions and hours

### DIFF
--- a/src/components/Rescue/Rescue.children.js
+++ b/src/components/Rescue/Rescue.children.js
@@ -10,6 +10,7 @@ import {
 import moment from 'moment'
 import { EditDelivery, GoogleMap, Input } from 'components'
 import {
+  DAYS,
   CLOUD_FUNCTION_URLS,
   createTimestamp,
   formatPhoneNumber,
@@ -548,6 +549,40 @@ export function Stop({ stops, s, i }) {
     ) : null
   }
 
+  function GetDayOfWeek() {
+    const formatDate = formatTimestamp(s.timestamp_scheduled_start)
+    const date = moment(formatDate).format('d')
+    const filterDate = s.location.hours
+      ? s.location.hours.filter(hour => hour.day_of_week === parseInt(date))
+      : null
+
+    return filterDate.length > 0
+      ? [
+          DAYS[filterDate[0].day_of_week],
+          ': ',
+          filterDate[0].time_open,
+          '-',
+          filterDate[0].time_close,
+        ]
+      : 'Not available today'
+  }
+
+  function StopHours() {
+    return s.location.hours ? (
+      <>
+        <Spacer height={16} />
+        <Text
+          type="small"
+          color="black"
+          classList={['Rescue-stop-instructions']}
+        >
+          <span>Open Hours: </span>
+          {GetDayOfWeek()}
+        </Text>
+      </>
+    ) : null
+  }
+
   function StopAddress() {
     const { address1, address2, city, state, zip } = s.location
     const button = (
@@ -799,6 +834,7 @@ export function Stop({ stops, s, i }) {
           />
           <Spacer height={8} />
           <StopInstructions />
+          <StopHours />
         </>
       )}
     </Card>

--- a/src/components/Rescue/Rescue.children.js
+++ b/src/components/Rescue/Rescue.children.js
@@ -7,6 +7,7 @@ import {
   Spacer,
   Text,
 } from '@sharingexcess/designsystem'
+import moment from 'moment'
 import { EditDelivery, GoogleMap, Input } from 'components'
 import {
   CLOUD_FUNCTION_URLS,
@@ -796,6 +797,8 @@ export function Stop({ stops, s, i }) {
             name={s.location.contact_name}
             number={s.location.contact_phone}
           />
+          <Spacer height={8} />
+          <StopInstructions />
         </>
       )}
     </Card>

--- a/src/components/Rescue/Rescue.children.js
+++ b/src/components/Rescue/Rescue.children.js
@@ -564,7 +564,7 @@ export function Stop({ stops, s, i }) {
           '-',
           filterDate[0].time_close,
         ]
-      : 'Not available today'
+      : "No information on this location's open hours."
   }
 
   function StopHours() {

--- a/src/components/Rescue/Rescue.children.js
+++ b/src/components/Rescue/Rescue.children.js
@@ -564,7 +564,7 @@ export function Stop({ stops, s, i }) {
           '-',
           filterDate[0].time_close,
         ]
-      : "No information on this location's open hours."
+      : 'Not available today'
   }
 
   function StopHours() {


### PR DESCRIPTION
- Instructions and open hours are shown on stop card. Especially, for open hours, it only shows the hour for the exact day of week that was scheduled, instead of showing all their availabilities.

![image](https://user-images.githubusercontent.com/60908199/156908413-51b5bff0-8af6-4852-a2ad-da36592cef66.png)

- If no open hours for that day is found, it notes "Not available today"
![image](https://user-images.githubusercontent.com/60908199/156908584-7007aa9a-243e-47bf-b62b-862251f2f422.png)

- If open hours have never been input into the location, "Open Hours" text is hidden


