### PR TITLE
Error with variable in Home.js

### DIFF
--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -58,7 +58,9 @@ export function Home() {
     )
   }
 
-  const { headerText, emoji } = user ? generateGreeting(user.displayName) : null
+  const { headerText, emoji } = user
+    ? generateGreeting(user.displayName)
+    : { headerText: null, emoji: null }
 
   return !user ? (
     <Landing />


### PR DESCRIPTION
Sam noticed that line 61 of Home.js caused an error when on the landing page.

![image](https://user-images.githubusercontent.com/78700199/159344020-c85e9531-bce0-4429-b7b8-c9e60e4b482f.png)

This fix properly declared the variables when the user had not signed in yet.