### PR TITLE
Get Directions button functionality

### DIFF
--- a/src/components/Rescue/Rescue.children.js
+++ b/src/components/Rescue/Rescue.children.js
@@ -669,17 +669,7 @@ export function Stop({ stops, s, i }) {
       setFirestoreData(['stops', s.id], {
         status: STATUSES.ACTIVE,
         timestamp_logged_start: createTimestamp(),
-      }).then(() =>
-        window.open(
-          generateDirectionsLink(
-            s.location.address1,
-            s.location.city,
-            s.location.state,
-            s.location.zip
-          ),
-          '_blank'
-        )
-      )
+      })
     }
     async function handleSkip() {
       if (s.organization.subtype === RECIPIENT_TYPES.HOME_DELIVERY) {
@@ -694,15 +684,25 @@ export function Stop({ stops, s, i }) {
 
     return (
       <>
-        <Button
-          type="primary"
-          color="blue"
-          size="large"
-          fullWidth
-          handler={handleClick}
+        <ExternalLink
+          to={generateDirectionsLink(
+            s.location.address1,
+            s.location.city,
+            s.location.state,
+            s.location.zip
+          )}
         >
-          Get Directions
-        </Button>
+          <Button
+            type="primary"
+            color="blue"
+            size="large"
+            fullWidth
+            handler={handleClick}
+            style={{ display: 'none' }}
+          >
+            Get Directions
+          </Button>
+        </ExternalLink>
         <Spacer height={24} />
         <Button
           type="tertiary"


### PR DESCRIPTION
The `Get Directions` button for stops in a rescue used `window.open` to redirect the user. Now, the `Get Direction` button uses the `External Link` component to redirect the user.

I was not able to test this because when I attempted to use the `on your network` link, I could not get out of the landing page.