### PR TITLE
changed getting last item in payload from Array.at() to square bracke…

### DIFF
--- a/frontend/src/hooks/useApi.js
+++ b/frontend/src/hooks/useApi.js
@@ -90,7 +90,7 @@ export function useApi(endpoint, params = null) {
                     : 1,
                 last:
                   payload.length && params && payload.length === params.limit
-                    ? payload.at(-1).id
+                    ? payload[payload.length - 1].id
                     : null,
                 loading: false,
               }))


### PR DESCRIPTION
Changed how to get last item in payload from using Array.prototype.at() to square bracket notation. Both perform the same operation. [https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at](see here)