### PR TITLE
Feat/cancel api endpoint

### DIFF
--- a/backend/functions/api/cancelRescue.js
+++ b/backend/functions/api/cancelRescue.js
@@ -20,13 +20,16 @@ async function cancelRescueEndpoint(request, response) {
         response.status(400).send('No payload received in request body.')
         return
       }
-      const canceled_rescue = await db.collection('rescues').doc(id).set(
-        {
-          status: payload.status,
-          notes: payload.notes,
-        },
-        { merge: true }
-      )
+      const canceled_rescue = await db
+        .collection('rescues')
+        .doc(id)
+        .set(
+          {
+            status: payload.status,
+            notes: payload.notes || '',
+          },
+          { merge: true }
+        )
       response.status(200).send(JSON.stringify(canceled_rescue))
       resolve()
     } catch (e) {
@@ -37,25 +40,3 @@ async function cancelRescueEndpoint(request, response) {
 }
 
 exports.cancelRescueEndpoint = cancelRescueEndpoint
-
-// async function cancelRescue(id, payload) {
-//   const payload = {
-//     status: STATUSES.CANCELLED,
-//     notes,
-//     impact_data_dairy: 0,
-//     impact_data_bakery: 0,
-//     impact_data_produce: 0,
-//     impact_data_meat_fish: 0,
-//     impact_data_non_perishable: 0,
-//     impact_data_prepared_frozen: 0,
-//     impact_data_mixed: 0,
-//     impact_data_other: 0,
-//     impact_data_total_weight: 0,
-//   }
-//   if (modalState.stop.type === 'delivery') {
-//     payload.percent_of_total_dropped = 0
-//   }
-//   await setFirestoreData(['stops', modalState.stop.id], payload)
-
-//   setModal()
-// }

--- a/backend/functions/api/cancelRescue.js
+++ b/backend/functions/api/cancelRescue.js
@@ -1,0 +1,61 @@
+// update firebase (cancel rescue)
+// update all stops (cancel stops)
+// delete calendar
+// return status code
+const { db } = require('../../helpers')
+
+async function cancelRescueEndpoint(request, response) {
+  return new Promise(async resolve => {
+    try {
+      console.log('running cancelRescue')
+      const { id } = request.params
+      console.log('Received id:', id)
+      if (!id) {
+        response.status(400).send('No id param received in request URL.')
+        return
+      }
+      const payload = JSON.parse(request.body)
+      console.log('Received payload:', payload)
+      if (!payload) {
+        response.status(400).send('No payload received in request body.')
+        return
+      }
+      const canceled_rescue = await db.collection('rescues').doc(id).set(
+        {
+          status: payload.status,
+          notes: payload.notes,
+        },
+        { merge: true }
+      )
+      response.status(200).send(JSON.stringify(canceled_rescue))
+      resolve()
+    } catch (e) {
+      console.error('Caught error:', e)
+      response.status(500).send(JSON.stringify(e))
+    }
+  })
+}
+
+exports.cancelRescueEndpoint = cancelRescueEndpoint
+
+// async function cancelRescue(id, payload) {
+//   const payload = {
+//     status: STATUSES.CANCELLED,
+//     notes,
+//     impact_data_dairy: 0,
+//     impact_data_bakery: 0,
+//     impact_data_produce: 0,
+//     impact_data_meat_fish: 0,
+//     impact_data_non_perishable: 0,
+//     impact_data_prepared_frozen: 0,
+//     impact_data_mixed: 0,
+//     impact_data_other: 0,
+//     impact_data_total_weight: 0,
+//   }
+//   if (modalState.stop.type === 'delivery') {
+//     payload.percent_of_total_dropped = 0
+//   }
+//   await setFirestoreData(['stops', modalState.stop.id], payload)
+
+//   setModal()
+// }

--- a/backend/functions/api/cancelStop.js
+++ b/backend/functions/api/cancelStop.js
@@ -1,16 +1,12 @@
-const { db } = require('../../helpers')
+const { db, fetchDocument } = require('../../helpers/functions')
 
 async function cancelStopEndpoint(request, response) {
   return new Promise(async resolve => {
     try {
       console.log('running cancelStop')
-      const { stop_id } = request.params
+      const { type, stop_id } = request.params
       console.log('Received stop_id:', stop_id)
-      // console.log('Received rescue_id:', id)
-      // if (!rescue_id) {
-      //   response.status(400).send('No id param received in request URL.')
-      //   return
-      // }
+      console.log('Received type:', type)
       if (!stop_id) {
         response.status(400).send('No id param received in request URL.')
         return
@@ -42,6 +38,15 @@ async function cancelStopEndpoint(request, response) {
           },
           { merge: true }
         )
+
+      if (type === 'delivery') {
+        canceled_stop = await db.collection('stops').doc(stop_id).set(
+          {
+            percent_of_total_dropped: 0,
+          },
+          { merge: true }
+        )
+      }
 
       response.status(200).send(JSON.stringify(canceled_stop))
       resolve()

--- a/backend/functions/api/cancelStop.js
+++ b/backend/functions/api/cancelStop.js
@@ -1,0 +1,55 @@
+const { db } = require('../../helpers')
+
+async function cancelStopEndpoint(request, response) {
+  return new Promise(async resolve => {
+    try {
+      console.log('running cancelStop')
+      const { stop_id } = request.params
+      console.log('Received stop_id:', stop_id)
+      // console.log('Received rescue_id:', id)
+      // if (!rescue_id) {
+      //   response.status(400).send('No id param received in request URL.')
+      //   return
+      // }
+      if (!stop_id) {
+        response.status(400).send('No id param received in request URL.')
+        return
+      }
+
+      const payload = JSON.parse(request.body)
+      console.log('Received payload:', payload)
+      if (!payload) {
+        response.status(400).send('No payload received in request body.')
+        return
+      }
+
+      const canceled_stop = await db
+        .collection('stops')
+        .doc(stop_id)
+        .set(
+          {
+            status: payload.status,
+            notes: payload.notes || '',
+            impact_data_dairy: 0,
+            impact_data_bakery: 0,
+            impact_data_produce: 0,
+            impact_data_meat_fish: 0,
+            impact_data_non_perishable: 0,
+            impact_data_prepared_frozen: 0,
+            impact_data_mixed: 0,
+            impact_data_other: 0,
+            impact_data_total_weight: 0,
+          },
+          { merge: true }
+        )
+
+      response.status(200).send(JSON.stringify(canceled_stop))
+      resolve()
+    } catch (e) {
+      console.error('Caught error:', e)
+      response.status(500).send(JSON.stringify(e))
+    }
+  })
+}
+
+exports.cancelStopEndpoint = cancelStopEndpoint

--- a/backend/functions/api/index.js
+++ b/backend/functions/api/index.js
@@ -28,6 +28,9 @@ api.post('/rescues/:id/update', (req, res) =>
 api.post('/stops/:id/update', (req, res) =>
   loadEndpoint('updateStop', req, res)
 )
+api.post('/rescues/:id/cancel', (req, res) =>
+  loadEndpoint('cancelRescue', req, res)
+)
 
 // we do this to dynamically load only the necessary endpoint code and improve cold start/runtime performance
 function loadEndpoint(name, request, response) {

--- a/backend/functions/api/index.js
+++ b/backend/functions/api/index.js
@@ -31,6 +31,9 @@ api.post('/stops/:id/update', (req, res) =>
 api.post('/rescues/:id/cancel', (req, res) =>
   loadEndpoint('cancelRescue', req, res)
 )
+api.post('/rescues/:id/:type/:stop_id/cancel', (req, res) =>
+  loadEndpoint('cancelStop', req, res)
+)
 
 // we do this to dynamically load only the necessary endpoint code and improve cold start/runtime performance
 function loadEndpoint(name, request, response) {

--- a/frontend/src/components/PickupReport/PickupReport.js
+++ b/frontend/src/components/PickupReport/PickupReport.js
@@ -158,11 +158,15 @@ export function PickupReport({ customSubmitHandler }) {
               </Text>
               <input
                 id={field}
+<<<<<<< HEAD
                 type="tel"
+=======
+                type="tel" // type tel, min 0, max 100000
+>>>>>>> 20285d1 (changed input for pickup report to telephone. max value is 99999)
                 minLength={0}
                 maxLength={5}
                 value={formData[field] === 0 ? '' : formData[field]}
-                onWheel={e => e.target.blur()}
+                // onWheel={e => e.target.blur()}
                 onChange={handleChange}
               />
               <Button

--- a/frontend/src/components/Rescue/Rescue.children.js
+++ b/frontend/src/components/Rescue/Rescue.children.js
@@ -35,12 +35,12 @@ import { useEffect } from 'react/cjs/react.development'
 import PickupIcon from 'assets/pickup.png'
 import DeliveryIcon from 'assets/delivery.png'
 
-export function RescueHeader({ rescue }) {
+export function RescueHeader({ rescue, refresh }) {
   const { setModal, setModalState } = useApp()
 
   function openRescueMenu() {
     setModal('RescueMenu')
-    setModalState({ rescue })
+    setModalState({ rescue, refresh })
   }
 
   return rescue ? (
@@ -82,21 +82,16 @@ export function RescueHeader({ rescue }) {
   ) : null
 }
 
-export function RescueMenu() {
-  const { setModal, modalState } = useApp()
+export function RescueMenu({ refresh }) {
+  const { setModal, modalState, setModalState } = useApp()
   const { user, admin } = useAuth()
   const { rescue_id } = useParams()
   const { rescue } = modalState
 
-  function RescueOption({ name, modalName }) {
+  function RescueOption({ label, action }) {
     return (
-      <Button
-        type="tertiary"
-        color="blue"
-        size="large"
-        handler={() => setModal(modalName)}
-      >
-        {name}
+      <Button type="tertiary" color="blue" size="large" handler={action}>
+        {label}
       </Button>
     )
   }
@@ -126,23 +121,61 @@ export function RescueMenu() {
           </>
         ) : null}
         <li>
-          <RescueOption modalName="AddRescueNotes" name="Add Notes to Rescue" />
+          <RescueOption
+            action={() => setModal('AddRescueNotes')}
+            label="Add Notes to Rescue"
+          />
         </li>
+<<<<<<< HEAD
+=======
+        {user.id === rescue.handler_id || admin ? (
+          <li>
+            <RescueOption
+              action={() => setModal('FinishRescue')}
+              label="Force Finish Rescue"
+            />
+          </li>
+        ) : null}
+>>>>>>> 9ccb58e (can cancel rescue via api now)
 
         {user.id === rescue.handler_id ? (
           <>
             <li>
-              <RescueOption modalName="DropRescue" name="Drop Rescue" />
+              <RescueOption
+                action={() => setModal('DropRescue')}
+                label="Drop Rescue"
+              />
             </li>
             <li>
-              <RescueOption modalName="ContactAdmin" name="Contact Admin" />
+              <RescueOption
+                action={() => setModal('ContactAdmin')}
+                label="Contact Admin"
+              />
             </li>
           </>
         ) : null}
         {admin ? (
+<<<<<<< HEAD
           <li>
             <RescueOption modalName="CancelRescue" name="Cancel Rescue" />
           </li>
+=======
+          <>
+            <li>
+              <Link to={`/rescues/${rescue_id}/edit`}>
+                <Button type="tertiary" color="blue" size="large">
+                  Edit Rescue
+                </Button>
+              </Link>
+            </li>
+            <li>
+              <RescueOption
+                action={() => setModal('CancelRescue')}
+                label="Cancel Rescue"
+              />
+            </li>
+          </>
+>>>>>>> 9ccb58e (can cancel rescue via api now)
         ) : null}
       </ul>
     </div>
@@ -241,25 +274,33 @@ export function CancelRescue() {
   const { modalState, setModal } = useApp()
   const [notes, setNotes] = useState()
   const { rescue } = modalState
-
   async function handleCancel() {
-    try {
-      await setFirestoreData(['rescues', rescue.id], {
-        status: STATUSES.CANCELLED,
-        notes,
-      })
-      await fetch(CLOUD_FUNCTION_URLS.deleteCalendarEvent, {
-        method: 'POST',
-        body: JSON.stringify({
-          calendarId: process.env.REACT_APP_GOOGLE_CALENDAR_ID,
-          eventId: rescue.google_calendar_event_id,
-        }),
-      })
-      setModal()
-    } catch (e) {
-      console.error('Error deleting calendar event:', e)
-    }
+    await SE_API.post(`/rescues/${rescue.id}/cancel`, {
+      status: STATUSES.CANCELLED,
+      notes,
+    })
+    // bad practice
+    modalState.refresh()
   }
+
+  // async function handleCancel() {
+  //   try {
+  //     await setFirestoreData(['rescues', rescue.id], {
+  //       status: STATUSES.CANCELLED,
+  //       notes,
+  //     })
+  //     await fetch(CLOUD_FUNCTION_URLS.deleteCalendarEvent, {
+  //       method: 'POST',
+  //       body: JSON.stringify({
+  //         calendarId: process.env.REACT_APP_GOOGLE_CALENDAR_ID,
+  //         eventId: rescue.google_calendar_event_id,
+  //       }),
+  //     })
+  //     setModal()
+  //   } catch (e) {
+  //     console.error('Error deleting calendar event:', e)
+  //   }
+  // }
 
   return (
     <>

--- a/frontend/src/components/Rescue/Rescue.children.js
+++ b/frontend/src/components/Rescue/Rescue.children.js
@@ -284,7 +284,6 @@ export function CancelRescue() {
 
     rescue.stop_ids.forEach(async stop_id => {
       const stop = await getFirestoreData(['stops', stop_id])
-      console.log(stop.type)
 
       await SE_API.post(
         `/rescues/${rescue.id}/${stop.type}/${stop_id}/cancel`,
@@ -294,13 +293,6 @@ export function CancelRescue() {
         }
       )
     })
-
-    // await SE_API.post('/calendar/delete', {
-    //   body: JSON.stringify({
-    //     calendarId: process.env.REACT_APP_GOOGLE_CALENDAR_ID,
-    //     eventId: rescue.google_calendar_event_id,
-    //   }),
-    // })
 
     await fetch(CLOUD_FUNCTION_URLS.deleteCalendarEvent, {
       method: 'POST',
@@ -313,25 +305,6 @@ export function CancelRescue() {
     // bad practice
     modalState.refresh()
   }
-
-  // async function handleCancel() {
-  //   try {
-  //     await setFirestoreData(['rescues', rescue.id], {
-  //       status: STATUSES.CANCELLED,
-  //       notes,
-  //     })
-  //     await fetch(CLOUD_FUNCTION_URLS.deleteCalendarEvent, {
-  //       method: 'POST',
-  //       body: JSON.stringify({
-  //         calendarId: process.env.REACT_APP_GOOGLE_CALENDAR_ID,
-  //         eventId: rescue.google_calendar_event_id,
-  //       }),
-  //     })
-  //     setModal()
-  //   } catch (e) {
-  //     console.error('Error deleting calendar event:', e)
-  //   }
-  // }
 
   return (
     <>

--- a/frontend/src/components/Rescue/Rescue.js
+++ b/frontend/src/components/Rescue/Rescue.js
@@ -25,6 +25,7 @@ export function Rescue() {
   useEffect(() => {
     // make the refresh function available in the modal state
     // for child components to gain access
+    console.log('setting modal state')
     setModalState(state => ({ ...state, refresh }))
   }, []) // eslint-disable-line
 
@@ -70,7 +71,7 @@ export function Rescue() {
         <Loading />
       ) : (
         <PullToRefresh onRefresh={handleRefresh}>
-          <RescueHeader rescue={rescue} />
+          <RescueHeader rescue={rescue} refresh={refresh} />
           <RescueActionButton rescue={rescue} />
           <Spacer height={32} />
           <section className="Stops">

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -47,19 +47,20 @@ import './styles/index.scss'
 // by default, we turn them on only for DEV, not PROD.
 // window.se_api_logs = IS_DEV_ENVIRONMENT
 window.se_api_logs = true
-
-Sentry.init({
-  dsn: SENTRY_DSN,
-  autoSessionTracking: true,
-  integrations: [
-    new Integrations.BrowserTracing(),
-    new Sentry.Integrations.Breadcrumbs({
-      console: false,
-    }),
-  ],
-  env: SENTRY_ENV,
-  release: VERSION,
-})
+if (process.env.NODE_ENV === 'production') {
+  Sentry.init({
+    dsn: SENTRY_DSN,
+    autoSessionTracking: true,
+    integrations: [
+      new Integrations.BrowserTracing(),
+      new Sentry.Integrations.Breadcrumbs({
+        console: false,
+      }),
+    ],
+    env: SENTRY_ENV,
+    release: VERSION,
+  })
+}
 
 // handle installed on home screen
 let debounce


### PR DESCRIPTION
Created API endpoint to cancel rescues, cancel stops and implements deleting calendar event.

Tests:
When cancelling a rescue, the status of the rescue should be `cancelled`, and all of the stops' statuses should also be `cancelled`. All of the impact data and `percent_of_total_dropped` should be set to zero.

To test this, we checked the database to make sure all corresponding status fields changed to `cancelled` and all the appropriate impact fields are set to zero after cancelling a rescue.