### PR TITLE
Creating file for createRescue

### DIFF
--- a/backend/functions/api/index.js
+++ b/backend/functions/api/index.js
@@ -36,6 +36,10 @@ api.post('/rescues/:id/:type/:stop_id/cancel', (req, res) =>
   loadEndpoint('cancelStop', req, res)
 )
 
+api.post('/rescues/:id/create', (req, res) =>
+  loadEndpoint('createRescue', req, res)
+)
+
 // we do this to dynamically load only the necessary endpoint code and improve cold start/runtime performance
 function loadEndpoint(name, request, response) {
   const module = require(`./${name}`)

--- a/backend/helpers/functions.js
+++ b/backend/helpers/functions.js
@@ -2,6 +2,7 @@ const admin = require('firebase-admin')
 exports.app = admin.initializeApp()
 exports.db = admin.firestore()
 const moment = require('moment-timezone')
+const fetch = require('node-fetch')
 
 exports.recalculateRescue = async id => {
   let rescue
@@ -151,7 +152,7 @@ exports.calculateTotalDistanceFromLocations = async (locations = []) => {
   )
   const base_url =
     'https://maps.googleapis.com/maps/api/distancematrix/json?units=imperial'
-  const API_KEY = process.env.GOOGLE_MAPS_API_KEY
+  const API_KEY = process.env.GOOGLE_DISTANCE_MATRIX_API
 
   let total_distance = 0
   let curr_location = locations.shift()
@@ -168,13 +169,19 @@ exports.calculateTotalDistanceFromLocations = async (locations = []) => {
       response.rows[0].elements[0].distance.text.split(' ')[0]
     )
 
-    console.log(distance)
+    console.log(
+      'Distance between',
+      curr_location,
+      'and',
+      locations[0],
+      distance
+    )
     total_distance += distance
     curr_location = locations.shift()
   }
 
-  console.log(total_distance, 'miles')
-  return `${total_distance} miles`
+  console.log('Total Distance:', total_distance, 'miles')
+  return total_distance
 }
 
 exports.fetchDocument = async (collection, id) => {

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "firebase": "^9.6.2",
     "firebase-admin": "^9.4.2",
-    "firebase-functions": "^3.19.0",
+    "firebase-functions": "^3.22.0",
     "googleapis": "^67.0.0",
     "moment": "^2.29.1",
     "moment-timezone": "^0.5.34"

--- a/frontend/src/components/EditRescue/EditRescue.js
+++ b/frontend/src/components/EditRescue/EditRescue.js
@@ -13,7 +13,6 @@ import {
   deleteFirestoreData,
   generateDirectionsLink,
   generateUniqueId,
-  setFirestoreData,
   STATUSES,
   updateGoogleCalendarEvent,
   SE_API,
@@ -127,7 +126,13 @@ export function EditRescue() {
     }
     const event = await updateGoogleCalendarEvent(formData, user.accessToken)
 
+    if (!event.id) {
+      alert('Error creating Google Calendar event. Please contact support!')
+      return
+    }
+
     await SE_API.post(`/rescues/${new_rescue_id}/create`, {
+      event: event,
       formData: formData,
       status_scheduled: STATUSES.SCHEDULED,
       timestamp_created: createTimestamp(),
@@ -139,31 +144,26 @@ export function EditRescue() {
       ),
     })
 
-    if (!event.id) {
-      alert('Error creating Google Calendar event. Please contact support!')
-      return
-    }
+    // const payload = {
+    //   id: new_rescue_id,
+    //   handler_id: formData.handler_id,
+    //   google_calendar_event_id: event.id,
+    //   stop_ids: formData.stops.map(s => s.id),
+    //   is_direct_link: formData.is_direct_link,
+    //   status: rescue ? rescue.status : STATUSES.SCHEDULED,
+    //   notes: rescue ? rescue.notes : '',
+    // timestamp_created: rescue ? rescue.timestamp_created : createTimestamp(),
+    //   timestamp_updated: createTimestamp(),
+    //   timestamp_scheduled_start: createTimestamp(
+    //     formData.timestamp_scheduled_start
+    //   ),
+    //   timestamp_scheduled_finish: createTimestamp(
+    //     formData.timestamp_scheduled_finish
+    //   ),
+    //   timestamp_logged_start: rescue ? rescue.timestamp_logged_start : null,
+    //   timestamp_logged_finish: rescue ? rescue.timestamp_logged_finish : null,
+    // }
 
-    const payload = {
-      id: new_rescue_id,
-      handler_id: formData.handler_id,
-      google_calendar_event_id: event.id,
-      stop_ids: formData.stops.map(s => s.id),
-      is_direct_link: formData.is_direct_link,
-      status: rescue ? rescue.status : STATUSES.SCHEDULED,
-      notes: rescue ? rescue.notes : '',
-      timestamp_created: rescue ? rescue.timestamp_created : createTimestamp(),
-      timestamp_updated: createTimestamp(),
-      timestamp_scheduled_start: createTimestamp(
-        formData.timestamp_scheduled_start
-      ),
-      timestamp_scheduled_finish: createTimestamp(
-        formData.timestamp_scheduled_finish
-      ),
-      timestamp_logged_start: rescue ? rescue.timestamp_logged_start : null,
-      timestamp_logged_finish: rescue ? rescue.timestamp_logged_finish : null,
-    }
-    // await setFirestoreData(['rescues', new_rescue_id], payload)
     setWorking(false)
     // navigate(`/rescues/${new_rescue_id}`)
   }

--- a/frontend/src/components/EditRescue/EditRescue.js
+++ b/frontend/src/components/EditRescue/EditRescue.js
@@ -16,6 +16,7 @@ import {
   setFirestoreData,
   STATUSES,
   updateGoogleCalendarEvent,
+  SE_API,
 } from 'helpers'
 import moment from 'moment'
 import {
@@ -126,44 +127,21 @@ export function EditRescue() {
     }
     const event = await updateGoogleCalendarEvent(formData, user.accessToken)
 
+    await SE_API.post(`/rescues/${new_rescue_id}/create`, {
+      formData: formData,
+      status_scheduled: STATUSES.SCHEDULED,
+      timestamp_created: createTimestamp(),
+      timestamp_scheduled_start: createTimestamp(
+        formData.timestamp_scheduled_start
+      ),
+      timestamp_scheduled_finish: createTimestamp(
+        formData.timestamp_scheduled_finish
+      ),
+    })
+
     if (!event.id) {
       alert('Error creating Google Calendar event. Please contact support!')
       return
-    }
-
-    for (const stop of formData.stops) {
-      const s = {
-        id: stop.id,
-        type: stop.type,
-        handler_id: formData.handler_id || null,
-        rescue_id: new_rescue_id,
-        organization_id: stop.organization_id,
-        location_id: stop.location_id,
-        status: stop.status || STATUSES.SCHEDULED,
-        timestamp_created: stop.timestamp_created || createTimestamp(),
-        timestamp_updated: createTimestamp(),
-        timestamp_logged_start: stop.timestamp_logged_start || null,
-        timestamp_logged_finish: stop.timestamp_logged_finish || null,
-        timestamp_scheduled_start: createTimestamp(
-          formData.timestamp_scheduled_start
-        ),
-        timestamp_scheduled_finish: createTimestamp(
-          formData.timestamp_scheduled_finish
-        ),
-        impact_data_dairy: stop.impact_data_dairy || 0,
-        impact_data_bakery: stop.impact_data_bakery || 0,
-        impact_data_produce: stop.impact_data_produce || 0,
-        impact_data_meat_fish: stop.impact_data_meat_fish || 0,
-        impact_data_non_perishable: stop.impact_data_non_perishable || 0,
-        impact_data_prepared_frozen: stop.impact_data_prepared_frozen || 0,
-        impact_data_mixed: stop.impact_data_mixed || 0,
-        impact_data_other: stop.impact_data_other || 0,
-        impact_data_total_weight: stop.impact_data_total_weight || 0,
-      }
-      if (stop.type === 'delivery') {
-        s.percent_of_total_dropped = stop.percent_of_total_dropped || 100
-      }
-      await setFirestoreData(['stops', stop.id], s)
     }
 
     const payload = {
@@ -185,9 +163,9 @@ export function EditRescue() {
       timestamp_logged_start: rescue ? rescue.timestamp_logged_start : null,
       timestamp_logged_finish: rescue ? rescue.timestamp_logged_finish : null,
     }
-    await setFirestoreData(['rescues', new_rescue_id], payload)
+    // await setFirestoreData(['rescues', new_rescue_id], payload)
     setWorking(false)
-    navigate(`/rescues/${new_rescue_id}`)
+    // navigate(`/rescues/${new_rescue_id}`)
   }
 
   async function handleRemoveStop(id, type) {

--- a/frontend/src/components/EditRescue/EditRescue.js
+++ b/frontend/src/components/EditRescue/EditRescue.js
@@ -124,15 +124,15 @@ export function EditRescue() {
         await deleteFirestoreData(['stops', stop.id])
       }
     }
-    const event = await updateGoogleCalendarEvent(formData, user.accessToken)
 
-    if (!event.id) {
-      alert('Error creating Google Calendar event. Please contact support!')
-      return
-    }
+    // const event = await updateGoogleCalendarEvent(formData, user.accessToken)
+    // if (!event.id) {
+    //   alert('Error creating Google Calendar event. Please contact support!')
+    //   return
+    // }
 
     await SE_API.post(`/rescues/${new_rescue_id}/create`, {
-      event: event,
+      // event: event,
       formData: formData,
       status_scheduled: STATUSES.SCHEDULED,
       timestamp_created: createTimestamp(),

--- a/frontend/src/components/EditRescue/EditRescue.js
+++ b/frontend/src/components/EditRescue/EditRescue.js
@@ -144,28 +144,8 @@ export function EditRescue() {
       ),
     })
 
-    // const payload = {
-    //   id: new_rescue_id,
-    //   handler_id: formData.handler_id,
-    //   google_calendar_event_id: event.id,
-    //   stop_ids: formData.stops.map(s => s.id),
-    //   is_direct_link: formData.is_direct_link,
-    //   status: rescue ? rescue.status : STATUSES.SCHEDULED,
-    //   notes: rescue ? rescue.notes : '',
-    // timestamp_created: rescue ? rescue.timestamp_created : createTimestamp(),
-    //   timestamp_updated: createTimestamp(),
-    //   timestamp_scheduled_start: createTimestamp(
-    //     formData.timestamp_scheduled_start
-    //   ),
-    //   timestamp_scheduled_finish: createTimestamp(
-    //     formData.timestamp_scheduled_finish
-    //   ),
-    //   timestamp_logged_start: rescue ? rescue.timestamp_logged_start : null,
-    //   timestamp_logged_finish: rescue ? rescue.timestamp_logged_finish : null,
-    // }
-
     setWorking(false)
-    // navigate(`/rescues/${new_rescue_id}`)
+    navigate(`/rescues/${new_rescue_id}`)
   }
 
   async function handleRemoveStop(id, type) {

--- a/frontend/src/components/PickupReport/PickupReport.js
+++ b/frontend/src/components/PickupReport/PickupReport.js
@@ -158,7 +158,11 @@ export function PickupReport({ customSubmitHandler }) {
               </Text>
               <input
                 id={field}
+<<<<<<< HEAD
                 type="tel"
+=======
+                type="tel" // type tel, min 0, max 100000
+>>>>>>> 8569853 (Fixed rebase issues)
                 minLength={0}
                 maxLength={5}
                 value={formData[field] === 0 ? '' : formData[field]}

--- a/frontend/src/components/PickupReport/PickupReport.js
+++ b/frontend/src/components/PickupReport/PickupReport.js
@@ -158,11 +158,7 @@ export function PickupReport({ customSubmitHandler }) {
               </Text>
               <input
                 id={field}
-<<<<<<< HEAD
                 type="tel"
-=======
-                type="tel" // type tel, min 0, max 100000
->>>>>>> 8569853 (Fixed rebase issues)
                 minLength={0}
                 maxLength={5}
                 value={formData[field] === 0 ? '' : formData[field]}


### PR DESCRIPTION
# Plan for create Rescue

Link for endpoint `rescues/:rescue_id/create`  - `rescue_id` in the link will be `new_rescue_id`
In the frontend, the call to the endpoint will look like `/rescues/$(new_rescue_id)/create`

Paylod:
{
  formData: formData,
  status: STATUSES.SCHEDULED
  timestampt: createTimestamp(),
}

Add `distance` as a field inside of the rescue object.

### Step 1
Move all create rescue functionality from frontend. Move code inside of the function `handleCreateRescue` into the file `createRescue`.

### Step 2
Combine the `createRescue` with updateGoogleCalender

### Step 3
Add calculate distance from inside the endpoint. Place this inside for loop when create the stops objects (line 134),

### Step 2
Add to existing updateRescue endpoint or create new endpoint that updates the rescue and corresponding stops. Here the `distance` field will get updated as the stops are updated.