### PR TITLE
Fixed rescues being set to scheduled

### DIFF
--- a/backend/functions/api/createRescue.js
+++ b/backend/functions/api/createRescue.js
@@ -52,6 +52,8 @@ async function createRescueEndpoint(request, response) {
       const timestamp_scheduled_finish = new Date(
         payload.timestamp_scheduled_finish
       )
+      const timestamp_updated = new Date(payload.timestamp_updated)
+
       console.log(
         '\n\n\nTIMESTAMPS:\n\n\n',
         '\nstart_parsed: ',
@@ -75,7 +77,8 @@ async function createRescueEndpoint(request, response) {
           status_scheduled,
           timestamp_created,
           timestamp_scheduled_start,
-          timestamp_scheduled_finish
+          timestamp_scheduled_finish,
+          timestamp_updated
         )
 
         stops_promises.push(
@@ -93,7 +96,8 @@ async function createRescueEndpoint(request, response) {
         status_scheduled,
         timestamp_created,
         timestamp_scheduled_start,
-        timestamp_scheduled_finish
+        timestamp_scheduled_finish,
+        timestamp_updated
       )
 
       console.log('Logging Created Rescue:', rescue_payload)
@@ -118,7 +122,8 @@ async function createRescuePayload(
   status_scheduled,
   timestamp_created,
   timestamp_scheduled_start,
-  timestamp_scheduled_finish
+  timestamp_scheduled_finish,
+  timestamp_updated
 ) {
   const resource = await createEventResource(
     formData,
@@ -154,7 +159,7 @@ async function createRescuePayload(
     status: status_scheduled,
     notes: '',
     timestamp_created: timestamp_created,
-    timestamp_updated: timestamp_created,
+    timestamp_updated: timestamp_updated,
     timestamp_scheduled_start: timestamp_scheduled_start,
     timestamp_scheduled_finish: timestamp_scheduled_finish,
     timestamp_logged_start: null,
@@ -172,7 +177,8 @@ async function createStopsPayload(
   status_scheduled,
   timestamp_created,
   timestamp_scheduled_start,
-  timestamp_scheduled_finish
+  timestamp_scheduled_finish,
+  timestamp_updated
 ) {
   const stop_payload = {
     id: stop.id,
@@ -185,7 +191,7 @@ async function createStopsPayload(
     timestamp_created: stop.timestamp_created
       ? new Date(stop.timestamp_created)
       : timestamp_created,
-    timestamp_updated: timestamp_created,
+    timestamp_updated: timestamp_updated,
     timestamp_logged_start:
       stop.timestamp_logged_start != null
         ? new Date(stop.timestamp_logged_start)

--- a/backend/functions/api/createRescue.js
+++ b/backend/functions/api/createRescue.js
@@ -53,6 +53,7 @@ async function createRescueEndpoint(request, response) {
         payload.timestamp_scheduled_finish
       )
       const timestamp_updated = new Date(payload.timestamp_updated)
+      const timestamp_logged_start = new Date(payload.timestamp_logged_start)
 
       console.log(
         '\n\n\nTIMESTAMPS:\n\n\n',
@@ -97,7 +98,8 @@ async function createRescueEndpoint(request, response) {
         timestamp_created,
         timestamp_scheduled_start,
         timestamp_scheduled_finish,
-        timestamp_updated
+        timestamp_updated,
+        timestamp_logged_start
       )
 
       console.log('Logging Created Rescue:', rescue_payload)
@@ -123,7 +125,8 @@ async function createRescuePayload(
   timestamp_created,
   timestamp_scheduled_start,
   timestamp_scheduled_finish,
-  timestamp_updated
+  timestamp_updated,
+  timestamp_logged_start
 ) {
   const resource = await createEventResource(
     formData,
@@ -162,7 +165,7 @@ async function createRescuePayload(
     timestamp_updated: timestamp_updated,
     timestamp_scheduled_start: timestamp_scheduled_start,
     timestamp_scheduled_finish: timestamp_scheduled_finish,
-    timestamp_logged_start: null,
+    timestamp_logged_start: timestamp_logged_start,
     timestamp_logged_finish: null,
     driving_distance: total_distance,
   }

--- a/frontend/src/components/EditRescue/EditRescue.js
+++ b/frontend/src/components/EditRescue/EditRescue.js
@@ -138,6 +138,9 @@ export function EditRescue() {
         formData.timestamp_scheduled_finish
       ).toDate(),
       timestamp_updated: createTimestamp(),
+      timestamp_logged_start: rescue?.timestamp_logged_start
+        ? rescue.timestamp_logged_start
+        : null,
     })
 
     setWorking(false)
@@ -448,7 +451,7 @@ export function EditRescue() {
           size="large"
           type="secondary"
           disabled={working}
-          handler={rescue_id ? handleUpdateRescue : handleCreateRescue}
+          handler={handleCreateRescue}
         >
           {generateSubmitButtonText()}
         </Button>

--- a/frontend/src/components/EditRescue/EditRescue.js
+++ b/frontend/src/components/EditRescue/EditRescue.js
@@ -125,29 +125,57 @@ export function EditRescue() {
       }
     }
 
-    // const event = await updateGoogleCalendarEvent(formData, user.accessToken)
-    // if (!event.id) {
-    //   alert('Error creating Google Calendar event. Please contact support!')
-    //   return
-    // }
-
     await SE_API.post(`/rescues/${new_rescue_id}/create`, {
-      // event: event,
       formData: formData,
-      status_scheduled: STATUSES.SCHEDULED,
-      timestamp_created: createTimestamp(),
+      status_scheduled: rescue?.status ? rescue.status : STATUSES.SCHEDULED,
+      timestamp_created: rescue?.timestamp_created
+        ? rescue.timestamp_created
+        : createTimestamp(),
       timestamp_scheduled_start: moment(
         formData.timestamp_scheduled_start
       ).toDate(),
       timestamp_scheduled_finish: moment(
         formData.timestamp_scheduled_finish
       ).toDate(),
+      timestamp_updated: createTimestamp(),
     })
 
     setWorking(false)
     navigate(`/rescues/${new_rescue_id}`)
   }
 
+  ///This is a function to call when we want to update a rescue rather than calling handleCreateRescue
+  /*
+  async function handleUpdateRescue() {
+    setWorking(true)
+    const new_rescue_id = rescue_id || (await generateUniqueId('rescues'))
+    if (rescue_id) {
+      // if this is an existing rescue with pre-created stops,
+      // make sure we delete any old and now deleted pickups and deliveries
+      for (const stop of deletedStops) {
+        await deleteFirestoreData(['stops', stop.id])
+      }
+    }
+
+    await SE_API.post(`/rescues/${rescue.id}/update`, {
+      timestamp_updated: createTimestamp(),
+      handler_id: formData.handler_id,
+      stops: formData.stops,
+      timestamp_scheduled_start: formData.timestamp_scheduled_finish,
+      timestamp_scheduled_finish: formData.timestamp_scheduled_finish,
+    })
+
+    for (const stop of formData.stops) {
+      SE_API.post(`/stops/${stop.id}/update`, {
+        timestamp_scheduled_start: formData.timestamp_scheduled_start,
+        timestamp_finished_start: formData.timestamp_finished_start,
+      })
+    }
+
+    setWorking(false)
+    navigate(`/rescues/${new_rescue_id}`)
+  }
+*/
   async function handleRemoveStop(id, type) {
     setFormData({
       ...formData,

--- a/frontend/src/components/EditRescue/EditRescue.js
+++ b/frontend/src/components/EditRescue/EditRescue.js
@@ -145,7 +145,6 @@ export function EditRescue() {
   }
 
   ///This is a function to call when we want to update a rescue rather than calling handleCreateRescue
-  /*
   async function handleUpdateRescue() {
     setWorking(true)
     const new_rescue_id = rescue_id || (await generateUniqueId('rescues'))
@@ -167,15 +166,19 @@ export function EditRescue() {
 
     for (const stop of formData.stops) {
       SE_API.post(`/stops/${stop.id}/update`, {
-        timestamp_scheduled_start: formData.timestamp_scheduled_start,
-        timestamp_finished_start: formData.timestamp_finished_start,
+        ...stop,
+        rescue_id: rescue_id,
+        timestamp_updated: createTimestamp(),
+        handler_id: formData.handler_id,
+        timestamp_scheduled_start: formData.timestamp_scheduled_finish,
+        timestamp_scheduled_finish: formData.timestamp_scheduled_finish,
       })
     }
 
     setWorking(false)
     navigate(`/rescues/${new_rescue_id}`)
   }
-*/
+
   async function handleRemoveStop(id, type) {
     setFormData({
       ...formData,
@@ -445,7 +448,7 @@ export function EditRescue() {
           size="large"
           type="secondary"
           disabled={working}
-          handler={handleCreateRescue}
+          handler={rescue_id ? handleUpdateRescue : handleCreateRescue}
         >
           {generateSubmitButtonText()}
         </Button>


### PR DESCRIPTION
Any time a rescue was updated, their status was being changed to `scheduled` rather than remaining as `active`. Conditionals were added to the createdRescue endpoint to handle this.