### PR TITLE
added condition to make sure handlers is not null before filtering it

### DIFF
--- a/frontend/src/components/Rescues/Rescues.Filters.js
+++ b/frontend/src/components/Rescues/Rescues.Filters.js
@@ -21,8 +21,9 @@ export function Filters({
   const { data: handlers } = useApi('/publicProfiles')
 
   function searchForHandler(value) {
-    return handlers.filter(i =>
-      i.name.toLowerCase().includes(value.toLowerCase())
+    return (
+      handlers &&
+      handlers.filter(i => i.name.toLowerCase().includes(value.toLowerCase()))
     )
   }
 


### PR DESCRIPTION
Added the condition `handlers && handlers.filter(...)` to make sure handlers is not null before filtering it 